### PR TITLE
Fix gh CLI shell escaping — use args array instead of sh -c

### DIFF
--- a/apps/agent/src/poller.ts
+++ b/apps/agent/src/poller.ts
@@ -18,8 +18,8 @@ export async function pollForIssue(): Promise<ParsedIssue | null> {
 
   const proc = Bun.spawn(
     [
-      'sh', '-c',
-      `gh issue list --repo ${REPO} --label agent-todo --json number,title,body,labels --search "sort:created-asc" --limit 10`,
+      'gh', 'issue', 'list', '--repo', REPO, '--label', 'agent-todo',
+      '--json', 'number,title,body,labels', '--search', 'sort:created-asc', '--limit', '10',
     ],
     { stdout: 'pipe', stderr: 'pipe' }
   )

--- a/apps/agent/src/tools/github.ts
+++ b/apps/agent/src/tools/github.ts
@@ -3,8 +3,8 @@ import { logger } from '../utils/logger'
 const WORK_DIR = process.env.WORK_DIR ?? '/tmp/agent-workspace'
 const REPO = process.env.GITHUB_REPO ?? 'jarlerik/evil_empire'
 
-async function gh(args: string, cwd?: string): Promise<string> {
-  const proc = Bun.spawn(['sh', '-c', `gh ${args}`], {
+async function gh(args: string[], cwd?: string): Promise<string> {
+  const proc = Bun.spawn(['gh', ...args], {
     cwd: cwd ?? process.env.HOME ?? '/tmp',
     stdout: 'pipe',
     stderr: 'pipe',
@@ -15,7 +15,7 @@ async function gh(args: string, cwd?: string): Promise<string> {
   const exitCode = await proc.exited
 
   if (exitCode !== 0) {
-    throw new Error(`gh ${args} failed (exit ${exitCode}): ${stderr.trim()}`)
+    throw new Error(`gh ${args.join(' ')} failed (exit ${exitCode}): ${stderr.trim()}`)
   }
 
   return stdout.trim()
@@ -25,7 +25,7 @@ export async function createPr(branch: string, title: string, body: string): Pro
   // Never create PR against main
   logger.info({ phase: 'github', action: 'create_pr', branch, title })
   const result = await gh(
-    `pr create --repo ${REPO} --base develop --head ${branch} --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}"`,
+    ['pr', 'create', '--repo', REPO, '--base', 'develop', '--head', branch, '--title', title, '--body', body],
     WORK_DIR
   )
   return result // returns PR URL
@@ -33,15 +33,15 @@ export async function createPr(branch: string, title: string, body: string): Pro
 
 export async function addIssueComment(issueNumber: number, comment: string): Promise<void> {
   logger.info({ phase: 'github', action: 'comment', issueNumber })
-  await gh(`issue comment ${issueNumber} --repo ${REPO} --body "${comment.replace(/"/g, '\\"')}"`)
+  await gh(['issue', 'comment', String(issueNumber), '--repo', REPO, '--body', comment])
 }
 
 export async function addLabel(issueNumber: number, label: string): Promise<void> {
-  await gh(`issue edit ${issueNumber} --repo ${REPO} --add-label "${label}"`)
+  await gh(['issue', 'edit', String(issueNumber), '--repo', REPO, '--add-label', label])
 }
 
 export async function removeLabel(issueNumber: number, label: string): Promise<void> {
-  await gh(`issue edit ${issueNumber} --repo ${REPO} --remove-label "${label}"`)
+  await gh(['issue', 'edit', String(issueNumber), '--repo', REPO, '--remove-label', label])
 }
 
 export interface ClosedPr {
@@ -54,7 +54,7 @@ export interface ClosedPr {
 export async function findRejectedPrs(): Promise<ClosedPr[]> {
   // Find PRs opened by the agent that were closed without merging
   const result = await gh(
-    `pr list --repo ${REPO} --state closed --label agent-done --json number,title,body,headRefName,mergedAt --limit 20`
+    ['pr', 'list', '--repo', REPO, '--state', 'closed', '--label', 'agent-done', '--json', 'number,title,body,headRefName,mergedAt', '--limit', '20']
   )
   const prs = JSON.parse(result) as Array<ClosedPr & { mergedAt: string }>
   // Closed but not merged = rejected
@@ -63,7 +63,7 @@ export async function findRejectedPrs(): Promise<ClosedPr[]> {
 
 export async function getPrReviewComments(prNumber: number): Promise<string> {
   const result = await gh(
-    `pr view ${prNumber} --repo ${REPO} --json reviews,comments --jq '[.reviews[].body, .comments[].body] | join("\\n---\\n")'`
+    ['pr', 'view', String(prNumber), '--repo', REPO, '--json', 'reviews,comments', '--jq', '[.reviews[].body, .comments[].body] | join("\\n---\\n")']
   )
   return result || 'No review comments found.'
 }
@@ -73,7 +73,7 @@ export async function createRetryIssue(originalTitle: string, originalBody: stri
   const body = `${originalBody}\n\n---\n\n## Previous attempt feedback\n\n${feedback}`
 
   const result = await gh(
-    `issue create --repo ${REPO} --title "${title.replace(/"/g, '\\"')}" --label agent-todo --label agent-retry --body "${body.replace(/"/g, '\\"')}"`
+    ['issue', 'create', '--repo', REPO, '--title', title, '--label', 'agent-todo', '--label', 'agent-retry', '--body', body]
   )
   // gh issue create returns the URL, extract issue number
   const match = result.match(/\/issues\/(\d+)/)
@@ -82,5 +82,5 @@ export async function createRetryIssue(originalTitle: string, originalBody: stri
 
 export async function closePrLabel(prNumber: number): Promise<void> {
   // Remove agent-done so we don't process this PR again
-  await gh(`pr edit ${prNumber} --repo ${REPO} --remove-label agent-done --add-label agent-rejected`)
+  await gh(['pr', 'edit', String(prNumber), '--repo', REPO, '--remove-label', 'agent-done', '--add-label', 'agent-rejected'])
 }


### PR DESCRIPTION
PR bodies with newlines/special chars broke when passed through shell interpolation, causing create_pr to fail silently and loop until SIGTERM.