### PR TITLE
Add per-exercise progression chart reached from the RMs screen

### DIFF
--- a/apps/mobile/PeakTrack/app/_layout.tsx
+++ b/apps/mobile/PeakTrack/app/_layout.tsx
@@ -58,6 +58,7 @@ export default function Layout() {
 								<Stack.Screen name="program-edit" />
 								<Stack.Screen name="program-assign" />
 								<Stack.Screen name="program-progression" />
+								<Stack.Screen name="exercise-progression" />
 								</Stack>
 								<UnitSelectionModal />
 							<StatusBar style="light" />

--- a/apps/mobile/PeakTrack/app/exercise-progression.tsx
+++ b/apps/mobile/PeakTrack/app/exercise-progression.tsx
@@ -1,0 +1,513 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+	View,
+	Text,
+	StyleSheet,
+	ScrollView,
+	Pressable,
+} from 'react-native';
+import Svg, { Polyline, Circle } from 'react-native-svg';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
+import { format } from 'date-fns';
+import {
+	fetchExerciseProgressionData,
+	ExerciseProgressionRow,
+} from '@evil-empire/peaktrack-services';
+import { useAuth } from '../contexts/AuthContext';
+import { useUserSettings } from '../contexts/UserSettingsContext';
+import { colors } from '../styles/common';
+import { LoadScreen } from './components/LoadScreen';
+import { NavigationBar } from '../components/NavigationBar';
+import {
+	buildExerciseSessionLayout,
+	ExerciseSessionLayout,
+} from '../lib/exerciseProgressionLayout';
+import type { TileColor } from '../lib/progressionLayoutCore';
+
+const MIN_SESSION_WIDTH = 44;
+const COLUMN_GAP = 8;
+const TILE_SIZE = 12;
+const TILE_GAP = 2;
+const TREND_HEIGHT = 140;
+const TREND_TOP_PADDING = 12;
+const TREND_BOTTOM_PADDING = 12;
+const SET_COLUMN_GAP = 2;
+
+function tileBackground(color: TileColor): { backgroundColor: string; opacity: number } {
+	switch (color) {
+		case 'bright':
+		case 'dark':
+			return { backgroundColor: colors.primary, opacity: 1 };
+		case 'faded-bright':
+		case 'faded-dark':
+			return { backgroundColor: colors.primary, opacity: 0.5 };
+		case 'dim':
+			return { backgroundColor: colors.primary, opacity: 0.2 };
+		case 'neutral':
+		default:
+			return { backgroundColor: '#2a2a2a', opacity: 1 };
+	}
+}
+
+function maxStackHeightTiles(layouts: ExerciseSessionLayout[]): number {
+	let max = 0;
+	for (const l of layouts) {
+		for (const col of l.columns) {
+			if (col.tiles.length > max) {
+				max = col.tiles.length;
+			}
+		}
+	}
+	return max;
+}
+
+function intrinsicSessionWidth(setCount: number): number {
+	if (setCount <= 0) {
+		return MIN_SESSION_WIDTH;
+	}
+	const stackWidth = setCount * TILE_SIZE + Math.max(0, setCount - 1) * SET_COLUMN_GAP;
+	return Math.max(MIN_SESSION_WIDTH, stackWidth);
+}
+
+function layoutGeometry(layouts: ExerciseSessionLayout[]): {
+	uniformWidth: number;
+	centers: number[];
+	totalWidth: number;
+} {
+	let uniformWidth = MIN_SESSION_WIDTH;
+	for (const l of layouts) {
+		const w = intrinsicSessionWidth(l.columns.length);
+		if (w > uniformWidth) {
+			uniformWidth = w;
+		}
+	}
+	const centers: number[] = [];
+	let x = 0;
+	for (let i = 0; i < layouts.length; i += 1) {
+		centers.push(x + uniformWidth / 2);
+		x += uniformWidth + (i < layouts.length - 1 ? COLUMN_GAP : 0);
+	}
+	return { uniformWidth, centers, totalWidth: x };
+}
+
+function formatDayLabel(iso: string): string {
+	try {
+		return format(new Date(iso), 'MMM d');
+	} catch {
+		return iso;
+	}
+}
+
+export default function ExerciseProgression() {
+	const { user } = useAuth();
+	const { settings } = useUserSettings();
+	const weightUnit = settings?.weight_unit || 'kg';
+	const params = useLocalSearchParams<{ exerciseName: string }>();
+	const exerciseName =
+		typeof params.exerciseName === 'string' ? params.exerciseName : null;
+
+	const [rows, setRows] = useState<ExerciseProgressionRow[] | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		if (!user || !exerciseName) {
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		const { data, error: err } = await fetchExerciseProgressionData(
+			user.id,
+			exerciseName,
+		);
+		if (err) {
+			setError(err);
+			setRows(null);
+		} else {
+			setRows(data ?? []);
+		}
+		setLoading(false);
+	}, [user, exerciseName]);
+
+	useFocusEffect(
+		useCallback(() => {
+			load();
+		}, [load]),
+	);
+
+	const layouts = useMemo<ExerciseSessionLayout[]>(() => {
+		if (!rows) {
+			return [];
+		}
+		const out: ExerciseSessionLayout[] = [];
+		for (const row of rows) {
+			const layout = buildExerciseSessionLayout({ row, weightUnit });
+			if (layout) {
+				out.push(layout);
+			}
+		}
+		return out;
+	}, [rows, weightUnit]);
+
+	const maxVolume = useMemo(() => {
+		let max = 0;
+		for (const l of layouts) {
+			if (l.volume > max) {
+				max = l.volume;
+			}
+		}
+		return max;
+	}, [layouts]);
+
+	const hasAnyCompound = useMemo(
+		() => layouts.some(l => l.isCompound),
+		[layouts],
+	);
+
+	if (loading) {
+		return (
+			<View style={styles.flex}>
+				<LoadScreen />
+				<NavigationBar />
+			</View>
+		);
+	}
+
+	if (error || !exerciseName) {
+		return (
+			<View style={styles.flex}>
+				<View style={styles.centerContainer}>
+					<Text style={styles.errorText}>{error ?? 'Missing exercise name'}</Text>
+					<Pressable onPress={() => router.back()} style={styles.backInline}>
+						<Ionicons name="chevron-back" size={20} color={colors.primary} />
+						<Text style={styles.backInlineText}>Go back</Text>
+					</Pressable>
+				</View>
+				<NavigationBar />
+			</View>
+		);
+	}
+
+	const { uniformWidth, centers: sessionCenters, totalWidth: chartWidth } =
+		layoutGeometry(layouts);
+	const stackHeight = maxStackHeightTiles(layouts) * (TILE_SIZE + TILE_GAP);
+	const trendPoints = layouts
+		.map((l, i) => {
+			if (maxVolume === 0) {
+				return null;
+			}
+			const yNorm = 1 - l.volume / maxVolume;
+			const y =
+				TREND_TOP_PADDING +
+				yNorm * (TREND_HEIGHT - TREND_TOP_PADDING - TREND_BOTTOM_PADDING);
+			return { x: sessionCenters[i] ?? 0, y };
+		})
+		.filter((p): p is { x: number; y: number } => p !== null);
+
+	return (
+		<View style={styles.flex}>
+			<View style={styles.headerRow}>
+				<Pressable
+					onPress={() => router.back()}
+					style={styles.backButton}
+					accessibilityLabel="Back"
+				>
+					<Ionicons name="chevron-back" size={24} color={colors.text} />
+				</Pressable>
+				<View style={styles.titleBlock}>
+					<Text style={styles.title} numberOfLines={1}>
+						{exerciseName}
+					</Text>
+				</View>
+			</View>
+
+			{layouts.length === 0 ? (
+				<View style={styles.emptyContainer}>
+					<Text style={styles.emptyText}>
+						No recorded sessions for {exerciseName} yet.
+					</Text>
+				</View>
+			) : (
+				<ScrollView
+					horizontal
+					style={styles.chartScroll}
+					contentContainerStyle={styles.chartContent}
+					showsHorizontalScrollIndicator={true}
+				>
+					<View style={[styles.chartInner, { width: chartWidth }]}>
+						<View
+							style={[styles.trendArea, { width: chartWidth, height: TREND_HEIGHT }]}
+						>
+							{trendPoints.length > 1 ? (
+								<Svg width={chartWidth} height={TREND_HEIGHT}>
+									<Polyline
+										points={trendPoints.map(p => `${p.x},${p.y}`).join(' ')}
+										fill="none"
+										stroke={colors.primary}
+										strokeWidth={2}
+									/>
+									{trendPoints.map((p, i) => (
+										<Circle
+											key={i}
+											cx={p.x}
+											cy={p.y}
+											r={3}
+											fill={colors.primary}
+											stroke={colors.primary}
+											strokeWidth={1}
+										/>
+									))}
+								</Svg>
+							) : null}
+						</View>
+
+						<View style={[styles.volumeRow, { width: chartWidth, gap: COLUMN_GAP }]}>
+							{layouts.map(l => (
+								<View key={l.logId} style={[styles.volumeCell, { width: uniformWidth }]}>
+									<Text style={styles.volumeText}>{l.volume}</Text>
+								</View>
+							))}
+						</View>
+
+						<View
+							style={[
+								styles.columnsRow,
+								{ width: chartWidth, height: stackHeight, gap: COLUMN_GAP },
+							]}
+						>
+							{layouts.map(l => (
+								<SessionStack
+									key={l.logId}
+									layout={l}
+									width={uniformWidth}
+									totalHeight={stackHeight}
+								/>
+							))}
+						</View>
+
+						<View style={[styles.labelRow, { width: chartWidth, gap: COLUMN_GAP }]}>
+							{layouts.map(l => (
+								<View key={l.logId} style={[styles.labelCell, { width: uniformWidth }]}>
+									{l.headerWeightLabel ? (
+										<Text style={styles.weightLabel}>{l.headerWeightLabel}</Text>
+									) : null}
+									<Text style={styles.dayLabel}>{formatDayLabel(l.workoutDate)}</Text>
+								</View>
+							))}
+						</View>
+					</View>
+				</ScrollView>
+			)}
+
+			{hasAnyCompound ? (
+				<View style={styles.legend}>
+					<LegendDot color={colors.primary} label="Analysed segment" />
+					<LegendDot color={colors.primary} opacity={0.5} label="Other segments" />
+				</View>
+			) : null}
+			<NavigationBar />
+		</View>
+	);
+}
+
+interface SessionStackProps {
+	layout: ExerciseSessionLayout;
+	width: number;
+	totalHeight: number;
+}
+
+function SessionStack({ layout, width, totalHeight }: SessionStackProps) {
+	const intrinsic = intrinsicSessionWidth(layout.columns.length);
+	const leftPad = Math.max(0, Math.round((width - intrinsic) / 2));
+	return (
+		<View
+			style={[
+				styles.sessionStack,
+				{ width, height: totalHeight, paddingLeft: leftPad, gap: SET_COLUMN_GAP },
+			]}
+		>
+			{layout.columns.map((col, idx) => (
+				<View
+					key={idx}
+					style={[
+						styles.setColumn,
+						{ width: TILE_SIZE, height: totalHeight, gap: TILE_GAP },
+					]}
+				>
+					{col.tiles.map((tile, tIdx) => {
+						const bg = tileBackground(tile);
+						return (
+							<View
+								key={tIdx}
+								style={[
+									styles.tile,
+									{
+										width: TILE_SIZE,
+										height: TILE_SIZE,
+										backgroundColor: bg.backgroundColor,
+										opacity: bg.opacity,
+									},
+								]}
+							/>
+						);
+					})}
+				</View>
+			))}
+		</View>
+	);
+}
+
+function LegendDot({
+	color,
+	label,
+	opacity = 1,
+}: {
+	color: string;
+	label: string;
+	opacity?: number;
+}) {
+	return (
+		<View style={styles.legendItem}>
+			<View style={[styles.legendDot, { backgroundColor: color, opacity }]} />
+			<Text style={styles.legendText}>{label}</Text>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	flex: {
+		flex: 1,
+		backgroundColor: colors.background,
+	},
+	centerContainer: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: colors.background,
+		padding: 24,
+	},
+	errorText: {
+		color: colors.error,
+		fontSize: 15,
+		marginBottom: 12,
+	},
+	backInline: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 4,
+	},
+	backInlineText: {
+		color: colors.primary,
+		fontSize: 14,
+	},
+	headerRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		paddingHorizontal: 16,
+		paddingTop: 16,
+		paddingBottom: 8,
+		gap: 8,
+	},
+	backButton: {
+		padding: 4,
+	},
+	titleBlock: {
+		flex: 1,
+	},
+	title: {
+		color: colors.primary,
+		fontSize: 20,
+		fontWeight: '700',
+	},
+	emptyContainer: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+		paddingHorizontal: 24,
+	},
+	emptyText: {
+		color: colors.textMuted,
+		fontSize: 14,
+		textAlign: 'center',
+	},
+	chartScroll: {
+		flex: 1,
+	},
+	chartContent: {
+		paddingHorizontal: 16,
+		paddingVertical: 8,
+	},
+	chartInner: {
+		flexDirection: 'column',
+	},
+	trendArea: {},
+	volumeRow: {
+		flexDirection: 'row',
+		alignItems: 'flex-end',
+		marginBottom: 6,
+	},
+	volumeCell: {
+		alignItems: 'center',
+	},
+	volumeText: {
+		color: colors.text,
+		fontSize: 11,
+		fontWeight: '600',
+	},
+	columnsRow: {
+		flexDirection: 'row',
+		alignItems: 'flex-end',
+	},
+	sessionStack: {
+		flexDirection: 'row',
+		alignItems: 'flex-end',
+	},
+	setColumn: {
+		flexDirection: 'column-reverse',
+		justifyContent: 'flex-start',
+		alignItems: 'center',
+	},
+	tile: {},
+	labelRow: {
+		flexDirection: 'row',
+		marginTop: 8,
+	},
+	labelCell: {
+		alignItems: 'center',
+	},
+	weightLabel: {
+		color: colors.primary,
+		fontSize: 10,
+		marginBottom: 2,
+	},
+	dayLabel: {
+		color: colors.text,
+		fontSize: 11,
+		fontWeight: '600',
+	},
+	legend: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		gap: 12,
+		paddingHorizontal: 16,
+		paddingVertical: 12,
+		borderTopWidth: 1,
+		borderTopColor: '#1a1a1a',
+	},
+	legendItem: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 6,
+	},
+	legendDot: {
+		width: 10,
+		height: 10,
+		borderRadius: 2,
+	},
+	legendText: {
+		color: colors.textMuted,
+		fontSize: 11,
+	},
+});

--- a/apps/mobile/PeakTrack/app/repetition-maximums.tsx
+++ b/apps/mobile/PeakTrack/app/repetition-maximums.tsx
@@ -1,15 +1,16 @@
 import { View, Text, Pressable, StyleSheet, KeyboardAvoidingView, Platform, ScrollView, Alert } from 'react-native';
 import React, { useState, useCallback } from 'react';
+import { router } from 'expo-router';
 import { useAuth } from '../contexts/AuthContext';
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { format } from 'date-fns';
 import { RmFormModal, RmFormData } from '../components/RmFormModal';
 import { useUserSettings } from '../contexts/UserSettingsContext';
-import { commonStyles } from '../styles/common';
+import { colors, commonStyles } from '../styles/common';
 import { NavigationBar } from '../components/NavigationBar';
 import { LoadScreen } from './components/LoadScreen';
-import { RepetitionMaximum, fetchRepetitionMaximums, createRepetitionMaximum, updateRepetitionMaximum, deleteRepetitionMaximum } from '@evil-empire/peaktrack-services';
+import { RepetitionMaximum, fetchRepetitionMaximums, createRepetitionMaximum, updateRepetitionMaximum, deleteRepetitionMaximum, fetchCompletedExerciseNameSet } from '@evil-empire/peaktrack-services';
 
 export default function RepetitionMaximums() {
 	const { user } = useAuth();
@@ -21,11 +22,13 @@ export default function RepetitionMaximums() {
 	const [isModalVisible, setIsModalVisible] = useState(false);
 	const [editingRm, setEditingRm] = useState<RepetitionMaximum | null>(null);
 	const [deletingId, setDeletingId] = useState<string | null>(null);
+	const [completedNames, setCompletedNames] = useState<Set<string>>(new Set());
 
 	useFocusEffect(
 		useCallback(() => {
 			if (user) {
 				fetchRms();
+				fetchCompletedNames();
 			}
 		}, [user]),
 	);
@@ -39,6 +42,14 @@ export default function RepetitionMaximums() {
 			setRms(data);
 		}
 		setIsFetching(false);
+	};
+
+	const fetchCompletedNames = async () => {
+		if (!user) {return;}
+		const { data } = await fetchCompletedExerciseNameSet(user.id);
+		if (data) {
+			setCompletedNames(data);
+		}
 	};
 
 	const handleOpenModal = (rm?: RepetitionMaximum) => {
@@ -165,9 +176,29 @@ export default function RepetitionMaximums() {
 						</View>
 					) : (
 						<View style={styles.listContainer}>
-							{groupedRmsArray.map(({ exerciseName, rms: exerciseRms }) => (
+							{groupedRmsArray.map(({ exerciseName, rms: exerciseRms }) => {
+								const hasLogs = completedNames.has(exerciseName.trim().toLowerCase());
+								return (
 								<View key={exerciseName} style={styles.exerciseGroup}>
-									<Text style={styles.exerciseName}>{exerciseName}</Text>
+									<View style={styles.exerciseHeader}>
+										<Text style={styles.exerciseName}>{exerciseName}</Text>
+										{hasLogs ? (
+											<Pressable
+												onPress={() =>
+													router.push({
+														pathname: '/exercise-progression',
+														params: { exerciseName },
+													})
+												}
+												style={[styles.progressionBtn, styles.progressionBtnPrimary]}
+												accessibilityRole="button"
+												accessibilityLabel="View progression"
+											>
+												<Ionicons name="trending-up-outline" size={16} color="#fff" />
+												<Text style={styles.progressionBtnText}>View progression</Text>
+											</Pressable>
+										) : null}
+									</View>
 									{exerciseRms.map((rm) => (
 										<View key={rm.id} style={styles.rmItem}>
 											<View style={styles.rmInfo}>
@@ -196,7 +227,8 @@ export default function RepetitionMaximums() {
 										</View>
 									))}
 								</View>
-							))}
+								);
+							})}
 						</View>
 					)}
 				</View>
@@ -260,11 +292,37 @@ const styles = StyleSheet.create({
 	exerciseGroup: {
 		marginBottom: 30,
 	},
+	exerciseHeader: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		marginBottom: 12,
+		gap: 8,
+	},
 	exerciseName: {
 		color: '#fff',
 		fontSize: 24,
 		fontWeight: 'bold',
-		marginBottom: 12,
+		flexShrink: 1,
+	},
+	progressionBtn: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: 6,
+		paddingVertical: 8,
+		paddingHorizontal: 12,
+		borderWidth: 1,
+		borderColor: colors.primary,
+		borderRadius: 6,
+	},
+	progressionBtnPrimary: {
+		backgroundColor: colors.primary,
+	},
+	progressionBtnText: {
+		color: '#fff',
+		fontSize: 12,
+		fontWeight: '600',
 	},
 	rmItem: {
 		flexDirection: 'row',

--- a/apps/mobile/PeakTrack/app/repetition-maximums.tsx
+++ b/apps/mobile/PeakTrack/app/repetition-maximums.tsx
@@ -148,7 +148,7 @@ export default function RepetitionMaximums() {
 				keyboardShouldPersistTaps="handled"
 			>
 				<View style={commonStyles.container}>
-					<Text style={commonStyles.title}>Max reps</Text>
+					<Text style={[commonStyles.title, styles.title]}>Max reps</Text>
 
 					<Pressable
 						style={styles.addButton}
@@ -218,6 +218,11 @@ export default function RepetitionMaximums() {
 }
 
 const styles = StyleSheet.create({
+	title: {
+		fontSize: 26,
+		textAlign: 'center',
+		marginBottom: 20,
+	},
 	addButton: {
 		flexDirection: 'row',
 		alignItems: 'center',

--- a/apps/mobile/PeakTrack/components/NavigationBar.tsx
+++ b/apps/mobile/PeakTrack/components/NavigationBar.tsx
@@ -19,7 +19,14 @@ interface NavigationItem {
 const navigationItems: NavigationItem[] = [
 	{ label: 'Home', href: '/', icon: 'home-outline', activeIcon: 'home' },
 	{ label: 'History', href: '/history', icon: 'time-outline', activeIcon: 'time' },
-	{ label: 'RMs', href: '/repetition-maximums', icon: 'podium-gold', activeIcon: 'podium-gold', iconFamily: 'material-community' },
+	{
+		label: 'RMs',
+		href: '/repetition-maximums',
+		icon: 'podium-gold',
+		activeIcon: 'podium-gold',
+		iconFamily: 'material-community',
+		matchPrefixes: ['/repetition-maximums', '/exercise-progression'],
+	},
 	{
 		label: 'Programs',
 		href: '/programs',

--- a/apps/mobile/PeakTrack/lib/__tests__/exerciseProgressionLayout.test.ts
+++ b/apps/mobile/PeakTrack/lib/__tests__/exerciseProgressionLayout.test.ts
@@ -1,0 +1,168 @@
+import type { ExerciseProgressionRow } from '@evil-empire/peaktrack-services';
+import {
+	escapeIlike,
+	splitCompoundName,
+} from '@evil-empire/peaktrack-services';
+import {
+	buildExerciseSessionLayout,
+	computeAttributedVolume,
+} from '../exerciseProgressionLayout';
+import { normalizePerformed } from '../progressionLayoutCore';
+
+function makeRow(overrides: Partial<ExerciseProgressionRow> = {}): ExerciseProgressionRow {
+	return {
+		logId: 'log-1',
+		workoutId: 'w-1',
+		workoutDate: '2026-04-01',
+		executedAt: '2026-04-01T10:00:00.000Z',
+		exerciseName: 'Back squat',
+		segmentIndex: 0,
+		isCompound: false,
+		log: {
+			id: 'log-1',
+			sets: 3,
+			repetitions: 5,
+			weight: 100,
+			weights: null,
+			compound_reps: null,
+			executed_at: '2026-04-01T10:00:00.000Z',
+		},
+		...overrides,
+	};
+}
+
+describe('computeAttributedVolume', () => {
+	it('multiplies sets × reps × weight for a non-compound log', () => {
+		const spec = normalizePerformed({
+			sets: 3,
+			repetitions: 5,
+			weight: 100,
+			weights: null,
+			compound_reps: null,
+		});
+		expect(spec).not.toBeNull();
+		expect(computeAttributedVolume(spec!)).toBe(3 * 5 * 100);
+	});
+
+	it('attributes compound volume using the first segment reps (worked example)', () => {
+		// "Power clean + Power jerk", compound_reps=[3,1], sets=3, weight=50.
+		// Plan §5 worked example: volume must be 3 × 3 × 50 = 450 for either
+		// segment under whole-set attribution.
+		const spec = normalizePerformed({
+			sets: 3,
+			repetitions: 4, // total reps per set, informational only
+			weight: 50,
+			weights: null,
+			compound_reps: [3, 1],
+		});
+		expect(spec).not.toBeNull();
+		expect(computeAttributedVolume(spec!)).toBe(3 * 3 * 50);
+	});
+
+	it('falls back to summed volume for wave sets (no compound segments)', () => {
+		const spec = normalizePerformed({
+			sets: 1,
+			repetitions: 3,
+			weight: 0,
+			weights: [80, 90, 100],
+			compound_reps: null,
+		});
+		expect(spec).not.toBeNull();
+		expect(computeAttributedVolume(spec!)).toBe(3 * 80 + 3 * 90 + 3 * 100);
+	});
+});
+
+describe('buildExerciseSessionLayout', () => {
+	it('builds bright tiles for every rep of a non-compound log', () => {
+		const row = makeRow();
+		const layout = buildExerciseSessionLayout({ row, weightUnit: 'kg' });
+		expect(layout).not.toBeNull();
+		expect(layout!.columns).toHaveLength(3);
+		for (const col of layout!.columns) {
+			expect(col.tiles).toHaveLength(5);
+			for (const tile of col.tiles) {
+				expect(tile).toBe('bright');
+			}
+		}
+		expect(layout!.volume).toBe(3 * 5 * 100);
+		expect(layout!.headerWeightLabel).toBe('100kg');
+	});
+
+	it('highlights the analysed compound segment and fades the others', () => {
+		const row = makeRow({
+			exerciseName: 'Power clean + Power jerk',
+			segmentIndex: 1,
+			isCompound: true,
+			log: {
+				id: 'log-2',
+				sets: 3,
+				repetitions: 4,
+				weight: 50,
+				weights: null,
+				compound_reps: [3, 1],
+				executed_at: '2026-04-01T10:00:00.000Z',
+			},
+		});
+		const layout = buildExerciseSessionLayout({ row, weightUnit: 'kg' });
+		expect(layout).not.toBeNull();
+		expect(layout!.columns).toHaveLength(3);
+		// Each column: 4 reps total, first 3 are the clean (segment 0, faded),
+		// last 1 is the jerk (segment 1, bright).
+		for (const col of layout!.columns) {
+			expect(col.tiles).toEqual(['faded-bright', 'faded-bright', 'faded-bright', 'bright']);
+		}
+		expect(layout!.volume).toBe(3 * 3 * 50);
+	});
+
+	it('respects the weight unit suffix without converting the stored value', () => {
+		const row = makeRow({
+			log: {
+				id: 'log-3',
+				sets: 1,
+				repetitions: 5,
+				weight: 225,
+				weights: null,
+				compound_reps: null,
+				executed_at: '2026-04-01T10:00:00.000Z',
+			},
+		});
+		const kg = buildExerciseSessionLayout({ row, weightUnit: 'kg' });
+		const lbs = buildExerciseSessionLayout({ row, weightUnit: 'lbs' });
+		expect(kg!.headerWeightLabel).toBe('225kg');
+		expect(lbs!.headerWeightLabel).toBe('225lbs');
+	});
+});
+
+describe('escapeIlike', () => {
+	it('escapes %, _, and \\ so user input does not become a LIKE wildcard', () => {
+		expect(escapeIlike('50%')).toBe('50\\%');
+		expect(escapeIlike('back_squat')).toBe('back\\_squat');
+		expect(escapeIlike('a\\b')).toBe('a\\\\b');
+	});
+
+	it('passes ordinary names through unchanged', () => {
+		expect(escapeIlike('Power clean')).toBe('Power clean');
+	});
+});
+
+describe('splitCompoundName', () => {
+	it('splits on + with flexible whitespace', () => {
+		expect(splitCompoundName('Power clean + Power jerk')).toEqual([
+			'Power clean',
+			'Power jerk',
+		]);
+		expect(splitCompoundName('Power clean+Power jerk')).toEqual([
+			'Power clean',
+			'Power jerk',
+		]);
+		expect(splitCompoundName('A  +  B +C')).toEqual(['A', 'B', 'C']);
+	});
+
+	it('returns a single segment for a non-compound name', () => {
+		expect(splitCompoundName('Back squat')).toEqual(['Back squat']);
+	});
+
+	it('drops empty segments', () => {
+		expect(splitCompoundName('Back squat + ')).toEqual(['Back squat']);
+	});
+});

--- a/apps/mobile/PeakTrack/lib/exerciseProgressionLayout.ts
+++ b/apps/mobile/PeakTrack/lib/exerciseProgressionLayout.ts
@@ -1,0 +1,105 @@
+import type { ExerciseProgressionRow } from '@evil-empire/peaktrack-services';
+import {
+	buildColumnTiles,
+	formatWeight,
+	normalizePerformed,
+	uniqueWeights,
+	volumeOf,
+	type ColumnLayout,
+	type NormalizedSpec,
+} from './progressionLayoutCore';
+
+export interface ExerciseSessionLayout {
+	logId: string;
+	workoutId: string;
+	workoutDate: string;
+	executedAt: string;
+	exerciseName: string;
+	isCompound: boolean;
+	segmentIndex: number;
+	columns: ColumnLayout[];
+	/** Volume attributed to the analysed exercise (see `computeAttributedVolume`). */
+	volume: number;
+	headerWeightLabel?: string;
+}
+
+/**
+ * Volume attributed to the analysed exercise for a single completed log.
+ *
+ * For non-compound matches this is the sum of `repsPerSet[i] × weightPerSet[i]`
+ * across all set columns — the ordinary training volume.
+ *
+ * For compound matches this plan locked in **whole-set attribution**: every
+ * segment of a compound is credited with `setCount × compound_reps[0] × weight`.
+ * Worked example from the plan: `"Power clean + Power jerk"`,
+ * `compound_reps = [3, 1]`, `sets = 3`, `weight = 50` — volume for either
+ * analysed segment is `3 × 3 × 50 = 450`.
+ */
+export function computeAttributedVolume(spec: NormalizedSpec): number {
+	const compound = spec.compoundSegments;
+	if (!compound || compound.length <= 1) {
+		return volumeOf(spec);
+	}
+	const primaryReps = compound[0] ?? 0;
+	let v = 0;
+	for (let i = 0; i < spec.setCount; i += 1) {
+		v += primaryReps * (spec.weightPerSet[i] ?? 0);
+	}
+	return v;
+}
+
+/**
+ * Build the per-column tile layout for a single completed log. Mirrors
+ * `buildSessionLayout` shape-wise but has no prescribed comparison — every
+ * tile renders in the bright base colour, with compound-segment fading driven
+ * by the analysed segment index.
+ */
+export function buildExerciseSessionLayout(input: {
+	row: ExerciseProgressionRow;
+	weightUnit: string;
+}): ExerciseSessionLayout | null {
+	const { row, weightUnit } = input;
+	const spec = normalizePerformed(row.log);
+	if (!spec) {
+		return null;
+	}
+
+	const columns: ColumnLayout[] = [];
+	for (let i = 0; i < spec.setCount; i += 1) {
+		const reps = spec.repsPerSet[i] ?? 0;
+		const tiles = buildColumnTiles(
+			reps,
+			'bright',
+			spec.compoundSegments,
+			row.segmentIndex,
+		);
+		columns.push({ tiles });
+	}
+
+	const uniqueWts = uniqueWeights(spec)
+		.slice()
+		.sort((a, b) => a - b);
+	let headerWeightLabel: string | undefined;
+	if (uniqueWts.length === 1 && uniqueWts[0] !== undefined) {
+		headerWeightLabel = formatWeight(uniqueWts[0], weightUnit);
+	} else if (uniqueWts.length >= 2) {
+		const min = uniqueWts[0];
+		const max = uniqueWts[uniqueWts.length - 1];
+		if (min !== undefined && max !== undefined) {
+			headerWeightLabel = `${min}-${formatWeight(max, weightUnit)}`;
+		}
+	}
+
+	return {
+		logId: row.logId,
+		workoutId: row.workoutId,
+		workoutDate: row.workoutDate,
+		executedAt: row.executedAt,
+		exerciseName: row.exerciseName,
+		isCompound: row.isCompound,
+		segmentIndex: row.segmentIndex,
+		columns,
+		volume: computeAttributedVolume(spec),
+		...(headerWeightLabel ? { headerWeightLabel } : {}),
+	};
+}

--- a/apps/mobile/PeakTrack/lib/progressionLayout.ts
+++ b/apps/mobile/PeakTrack/lib/progressionLayout.ts
@@ -3,38 +3,26 @@ import type {
 	ProgramExercise,
 	ProgramRepetitionMaximum,
 } from '@evil-empire/types';
-
-/**
- * Minimal shape shared by `ExercisePhase` and `ExecutionLogDetail`. The
- * progression view only needs the set/rep/weight dimensions to render tiles
- * and compute volume, so we type the performed input loosely to accept either.
- */
-export interface PerformedShape {
-	sets: number;
-	repetitions: number;
-	weight: number;
-	weights?: number[] | null;
-	compound_reps?: number[] | null;
-}
+import {
+	buildColumnTiles,
+	formatKg,
+	isWaveWeights,
+	normalizePerformed,
+	sum,
+	uniqueWeights,
+	volumeOf,
+	type ColumnLayout,
+	type NormalizedSpec,
+	type PerformedShape,
+} from './progressionLayoutCore';
 import {
 	exerciseNeedsRmSnapshot,
 	resolveWeightsFromSnapshot,
 } from './resolveProgramWeights';
 
-export type TileColor =
-	| 'bright'
-	| 'faded-bright'
-	| 'dark'
-	| 'faded-dark'
-	| 'dim'
-	| 'neutral';
-
-export interface ColumnLayout {
-	/** Tiles bottom-to-top. */
-	tiles: TileColor[];
-	/** Weight label shown under the column (waves only). */
-	weightLabel?: string;
-}
+// Re-export types so existing imports from './progressionLayout' keep working.
+export type { ColumnLayout, PerformedShape, TileColor } from './progressionLayoutCore';
+export { normalizePerformed } from './progressionLayoutCore';
 
 export interface SessionLayout {
 	sessionId: string;
@@ -63,31 +51,6 @@ const DAY_LABELS: Record<number, string> = {
 	6: 'Sat',
 	7: 'Sun',
 };
-
-interface NormalizedSpec {
-	/** Number of set columns. */
-	setCount: number;
-	/** Reps per set column (length == setCount). */
-	repsPerSet: number[];
-	/** Weight per set column (length == setCount). */
-	weightPerSet: number[];
-	/** True when the spec is a wave (per-set weights differ). */
-	isWave: boolean;
-	/** Compound segment boundaries within a set, e.g. [2, 2] for `2 + 2`. */
-	compoundSegments?: number[];
-}
-
-function sum(xs: number[]): number {
-	let total = 0;
-	for (const x of xs) {
-		total += x;
-	}
-	return total;
-}
-
-function isWaveWeights(weights: number[] | undefined): weights is number[] {
-	return Array.isArray(weights) && weights.length > 1;
-}
 
 /**
  * Turn a parsed prescribed exercise into a uniform shape the renderer can
@@ -164,115 +127,6 @@ function normalizeFromParsed(
 		weightPerSet: new Array(sets).fill(resolvedWeight),
 		isWave: false,
 	};
-}
-
-/**
- * Turn a performed `PerformedShape` (execution log or phase) into the same
- * shape as a prescribed spec. This lets the renderer compare like-with-like.
- */
-export function normalizePerformed(performed: PerformedShape): NormalizedSpec | null {
-	const compound = performed.compound_reps ?? undefined;
-	const weights = performed.weights ?? undefined;
-
-	if (isWaveWeights(weights) && compound && compound.length === weights.length) {
-		return {
-			setCount: compound.length,
-			repsPerSet: compound,
-			weightPerSet: weights,
-			isWave: true,
-		};
-	}
-
-	if (isWaveWeights(weights) && !compound) {
-		const reps = performed.repetitions > 0 ? performed.repetitions : 0;
-		return {
-			setCount: weights.length,
-			repsPerSet: new Array(weights.length).fill(reps),
-			weightPerSet: weights,
-			isWave: true,
-		};
-	}
-
-	if (compound && compound.length > 0 && !isWaveWeights(weights)) {
-		const repsTotal = sum(compound);
-		const sets = performed.sets > 0 ? performed.sets : 1;
-		return {
-			setCount: sets,
-			repsPerSet: new Array(sets).fill(repsTotal),
-			weightPerSet: new Array(sets).fill(performed.weight),
-			isWave: false,
-			compoundSegments: compound,
-		};
-	}
-
-	const sets = performed.sets > 0 ? performed.sets : 1;
-	const reps = performed.repetitions > 0 ? performed.repetitions : 0;
-	return {
-		setCount: sets,
-		repsPerSet: new Array(sets).fill(reps),
-		weightPerSet: new Array(sets).fill(performed.weight),
-		isWave: false,
-	};
-}
-
-function volumeOf(spec: NormalizedSpec): number {
-	let v = 0;
-	for (let i = 0; i < spec.setCount; i += 1) {
-		v += (spec.repsPerSet[i] ?? 0) * (spec.weightPerSet[i] ?? 0);
-	}
-	return v;
-}
-
-function formatKg(kg: number): string {
-	if (Number.isInteger(kg)) {
-		return `${kg}kg`;
-	}
-	return `${kg.toFixed(1)}kg`;
-}
-
-function uniqueWeights(spec: NormalizedSpec): number[] {
-	return Array.from(new Set(spec.weightPerSet));
-}
-
-function buildColumnTiles(
-	repsInColumn: number,
-	baseColor: 'bright' | 'dark' | 'dim' | 'neutral',
-	compoundSegments: number[] | undefined,
-): TileColor[] {
-	if (repsInColumn <= 0) {
-		return [];
-	}
-	const fadedBase: TileColor =
-		baseColor === 'bright'
-			? 'faded-bright'
-			: baseColor === 'dark'
-				? 'faded-dark'
-				: baseColor;
-	const full: TileColor = baseColor;
-
-	// Compound: first segment full, subsequent segments faded. `tiles` is
-	// ordered bottom-to-top to match the visual stack.
-	if (compoundSegments && compoundSegments.length > 1) {
-		const tiles: TileColor[] = [];
-		for (let i = 0; i < compoundSegments.length; i += 1) {
-			const segmentReps = compoundSegments[i] ?? 0;
-			const color = i === 0 ? full : fadedBase;
-			for (let r = 0; r < segmentReps; r += 1) {
-				tiles.push(color);
-			}
-		}
-		// Trim/pad to match actual repsInColumn — performed can fall short.
-		while (tiles.length > repsInColumn) {
-			tiles.pop();
-		}
-		return tiles;
-	}
-
-	const tiles: TileColor[] = [];
-	for (let r = 0; r < repsInColumn; r += 1) {
-		tiles.push(full);
-	}
-	return tiles;
 }
 
 /**

--- a/apps/mobile/PeakTrack/lib/progressionLayoutCore.ts
+++ b/apps/mobile/PeakTrack/lib/progressionLayoutCore.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared primitives for progression-style chart layouts.
+ *
+ * Both `progressionLayout.ts` (per-program exercise) and
+ * `exerciseProgressionLayout.ts` (per-user exercise) build stacked-tile
+ * visualisations over the same data shape — sets × reps × weight, with optional
+ * per-set weight waves and compound rep segments. This module owns that
+ * shape-and-tile primitive layer; the per-screen modules add the
+ * screen-specific aggregation on top.
+ */
+
+export type TileColor =
+	| 'bright'
+	| 'faded-bright'
+	| 'dark'
+	| 'faded-dark'
+	| 'dim'
+	| 'neutral';
+
+export interface ColumnLayout {
+	/** Tiles bottom-to-top. */
+	tiles: TileColor[];
+	/** Weight label shown under the column (waves only). */
+	weightLabel?: string;
+}
+
+/**
+ * Minimal shape shared by `ExercisePhase` and `ExecutionLogDetail`. Any
+ * caller that can produce sets/reps/weight (with optional waves/compound
+ * metadata) can plug into this layout layer.
+ */
+export interface PerformedShape {
+	sets: number;
+	repetitions: number;
+	weight: number;
+	weights?: number[] | null;
+	compound_reps?: number[] | null;
+}
+
+export interface NormalizedSpec {
+	/** Number of set columns. */
+	setCount: number;
+	/** Reps per set column (length == setCount). */
+	repsPerSet: number[];
+	/** Weight per set column (length == setCount). */
+	weightPerSet: number[];
+	/** True when the spec is a wave (per-set weights differ). */
+	isWave: boolean;
+	/** Compound segment boundaries within a set, e.g. [2, 2] for `2 + 2`. */
+	compoundSegments?: number[];
+}
+
+export function sum(xs: number[]): number {
+	let total = 0;
+	for (const x of xs) {
+		total += x;
+	}
+	return total;
+}
+
+export function isWaveWeights(weights: number[] | undefined): weights is number[] {
+	return Array.isArray(weights) && weights.length > 1;
+}
+
+/**
+ * Turn a performed `PerformedShape` (execution log or phase) into a
+ * `NormalizedSpec` the renderer can consume. Returns `null` only if the
+ * shape is structurally invalid, which today it never is.
+ */
+export function normalizePerformed(performed: PerformedShape): NormalizedSpec | null {
+	const compound = performed.compound_reps ?? undefined;
+	const weights = performed.weights ?? undefined;
+
+	if (isWaveWeights(weights) && compound && compound.length === weights.length) {
+		return {
+			setCount: compound.length,
+			repsPerSet: compound,
+			weightPerSet: weights,
+			isWave: true,
+		};
+	}
+
+	if (isWaveWeights(weights) && !compound) {
+		const reps = performed.repetitions > 0 ? performed.repetitions : 0;
+		return {
+			setCount: weights.length,
+			repsPerSet: new Array(weights.length).fill(reps),
+			weightPerSet: weights,
+			isWave: true,
+		};
+	}
+
+	if (compound && compound.length > 0 && !isWaveWeights(weights)) {
+		const repsTotal = sum(compound);
+		const sets = performed.sets > 0 ? performed.sets : 1;
+		return {
+			setCount: sets,
+			repsPerSet: new Array(sets).fill(repsTotal),
+			weightPerSet: new Array(sets).fill(performed.weight),
+			isWave: false,
+			compoundSegments: compound,
+		};
+	}
+
+	const sets = performed.sets > 0 ? performed.sets : 1;
+	const reps = performed.repetitions > 0 ? performed.repetitions : 0;
+	return {
+		setCount: sets,
+		repsPerSet: new Array(sets).fill(reps),
+		weightPerSet: new Array(sets).fill(performed.weight),
+		isWave: false,
+	};
+}
+
+export function volumeOf(spec: NormalizedSpec): number {
+	let v = 0;
+	for (let i = 0; i < spec.setCount; i += 1) {
+		v += (spec.repsPerSet[i] ?? 0) * (spec.weightPerSet[i] ?? 0);
+	}
+	return v;
+}
+
+export function uniqueWeights(spec: NormalizedSpec): number[] {
+	return Array.from(new Set(spec.weightPerSet));
+}
+
+/**
+ * Bottom-to-top tile colours for a single column of a compound or
+ * non-compound stack.
+ *
+ * `highlightSegmentIndex` selects which compound segment gets the full-colour
+ * tiles (others render faded). Defaults to `0`, matching the program-progression
+ * convention where segment 0 is the "primary" segment (e.g. the clean in a
+ * clean + jerk). Exercise-progression passes the segment index of the analysed
+ * exercise so the right sub-movement is highlighted.
+ */
+export function buildColumnTiles(
+	repsInColumn: number,
+	baseColor: 'bright' | 'dark' | 'dim' | 'neutral',
+	compoundSegments: number[] | undefined,
+	highlightSegmentIndex: number = 0,
+): TileColor[] {
+	if (repsInColumn <= 0) {
+		return [];
+	}
+	const fadedBase: TileColor =
+		baseColor === 'bright'
+			? 'faded-bright'
+			: baseColor === 'dark'
+				? 'faded-dark'
+				: baseColor;
+	const full: TileColor = baseColor;
+
+	// Compound: highlighted segment full, others faded. `tiles` is ordered
+	// bottom-to-top to match the visual stack.
+	if (compoundSegments && compoundSegments.length > 1) {
+		const tiles: TileColor[] = [];
+		for (let i = 0; i < compoundSegments.length; i += 1) {
+			const segmentReps = compoundSegments[i] ?? 0;
+			const color = i === highlightSegmentIndex ? full : fadedBase;
+			for (let r = 0; r < segmentReps; r += 1) {
+				tiles.push(color);
+			}
+		}
+		// Trim to match actual repsInColumn — performed can fall short.
+		while (tiles.length > repsInColumn) {
+			tiles.pop();
+		}
+		return tiles;
+	}
+
+	const tiles: TileColor[] = [];
+	for (let r = 0; r < repsInColumn; r += 1) {
+		tiles.push(full);
+	}
+	return tiles;
+}
+
+export function formatKg(kg: number): string {
+	if (Number.isInteger(kg)) {
+		return `${kg}kg`;
+	}
+	return `${kg.toFixed(1)}kg`;
+}
+
+/**
+ * Format a raw stored weight value with the user's preferred unit appended.
+ * No conversion — weights are stored and displayed as-is.
+ */
+export function formatWeight(value: number, unit: string): string {
+	const rendered = Number.isInteger(value) ? `${value}` : value.toFixed(1);
+	return `${rendered}${unit}`;
+}

--- a/packages/peaktrack-services/src/exerciseProgressionService.ts
+++ b/packages/peaktrack-services/src/exerciseProgressionService.ts
@@ -1,0 +1,234 @@
+import { getSupabaseClient } from './client';
+import { ServiceResult } from './types';
+
+/**
+ * One completed execution log for an exercise-progression chart point.
+ * Mirrors the subset of `workout_execution_logs` needed for tile + volume
+ * rendering — no circuit / RIR / notes metadata.
+ */
+export interface ExerciseProgressionLog {
+	id: string;
+	sets: number;
+	repetitions: number;
+	weight: number;
+	weights: number[] | null;
+	compound_reps: number[] | null;
+	executed_at: string;
+}
+
+export interface ExerciseProgressionRow {
+	logId: string;
+	workoutId: string;
+	/** ISO date (YYYY-MM-DD). */
+	workoutDate: string;
+	/** ISO timestamp, used as secondary sort key. */
+	executedAt: string;
+	/** Original compound-preserving exercise name, e.g. `"Power clean + Power jerk"`. */
+	exerciseName: string;
+	/** Position of the analysed target within the compound (0 for non-compound). */
+	segmentIndex: number;
+	isCompound: boolean;
+	log: ExerciseProgressionLog;
+}
+
+export interface FetchExerciseProgressionOptions {
+	/** Rolling window in months. Default 24. Pass `Infinity` for all history. */
+	monthsBack?: number;
+}
+
+/**
+ * Escape the literal % and _ wildcards (and the escape char itself) so a user
+ * entering e.g. `"50%"` as an exercise name does not turn into a LIKE wildcard.
+ */
+export function escapeIlike(target: string): string {
+	return target.replace(/[\\%_]/g, '\\$&');
+}
+
+function normalizeName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+export function splitCompoundName(name: string): string[] {
+	return name
+		.split(/\s*\+\s*/)
+		.map(s => s.trim())
+		.filter(Boolean);
+}
+
+function computeCutoffDate(monthsBack: number): string | null {
+	if (!Number.isFinite(monthsBack) || monthsBack <= 0) {
+		return null;
+	}
+	const cutoff = new Date();
+	cutoff.setMonth(cutoff.getMonth() - monthsBack);
+	return cutoff.toISOString().slice(0, 10);
+}
+
+interface RawLog {
+	id: string;
+	sets: number;
+	repetitions: number;
+	weight: number;
+	weights: number[] | null;
+	compound_reps: number[] | null;
+	execution_status: string;
+	executed_at: string;
+}
+
+interface RawExercise {
+	id: string;
+	name: string;
+	workout_execution_logs: RawLog[];
+}
+
+interface RawWorkout {
+	id: string;
+	workout_date: string | null;
+	exercises: RawExercise[];
+}
+
+/**
+ * Fetch every completed execution log for the target exercise (direct or as a
+ * compound segment) within the rolling window. Emits one row per log — an
+ * exercise with three phase logs in one workout produces three adjacent chart
+ * points. Rows are sorted `(workout_date, executed_at, logId)`.
+ */
+export async function fetchExerciseProgressionData(
+	userId: string,
+	exerciseName: string,
+	options: FetchExerciseProgressionOptions = {},
+): Promise<ServiceResult<ExerciseProgressionRow[]>> {
+	const target = normalizeName(exerciseName);
+	if (!target) {
+		return { data: [], error: null };
+	}
+	const escaped = escapeIlike(target);
+
+	const supabase = getSupabaseClient();
+	const cutoffDate = computeCutoffDate(options.monthsBack ?? 24);
+
+	let query = supabase
+		.from('workouts')
+		.select(
+			`
+			id,
+			workout_date,
+			exercises!inner (
+				id,
+				name,
+				workout_execution_logs!inner (
+					id,
+					sets,
+					repetitions,
+					weight,
+					weights,
+					compound_reps,
+					execution_status,
+					executed_at
+				)
+			)
+		`,
+		)
+		.eq('user_id', userId)
+		.ilike('exercises.name', `%${escaped}%`)
+		.eq('exercises.workout_execution_logs.execution_status', 'completed')
+		.order('workout_date', { ascending: true });
+
+	if (cutoffDate) {
+		query = query.gte('workout_date', cutoffDate);
+	}
+
+	const { data, error } = await query;
+	if (error) {
+		return { data: null, error: error.message };
+	}
+
+	const rows: ExerciseProgressionRow[] = [];
+	for (const w of (data ?? []) as RawWorkout[]) {
+		const workoutDate = w.workout_date;
+		for (const ex of w.exercises ?? []) {
+			const segments = splitCompoundName(ex.name).map(normalizeName);
+			const segmentIndex = segments.findIndex(s => s === target);
+			if (segmentIndex < 0) {
+				continue;
+			}
+			const isCompound = segments.length > 1;
+			for (const log of ex.workout_execution_logs ?? []) {
+				if (log.execution_status !== 'completed') {
+					continue;
+				}
+				const effectiveDate = workoutDate ?? log.executed_at.slice(0, 10);
+				rows.push({
+					logId: log.id,
+					workoutId: w.id,
+					workoutDate: effectiveDate,
+					executedAt: log.executed_at,
+					exerciseName: ex.name,
+					segmentIndex,
+					isCompound,
+					log: {
+						id: log.id,
+						sets: log.sets,
+						repetitions: log.repetitions,
+						weight: log.weight,
+						weights: log.weights,
+						compound_reps: log.compound_reps,
+						executed_at: log.executed_at,
+					},
+				});
+			}
+		}
+	}
+
+	rows.sort((a, b) => {
+		if (a.workoutDate !== b.workoutDate) {
+			return a.workoutDate < b.workoutDate ? -1 : 1;
+		}
+		if (a.executedAt !== b.executedAt) {
+			return a.executedAt < b.executedAt ? -1 : 1;
+		}
+		if (a.logId !== b.logId) {
+			return a.logId < b.logId ? -1 : 1;
+		}
+		return 0;
+	});
+
+	return { data: rows, error: null };
+}
+
+/**
+ * Fetch the set of exercise-segment names the user has at least one completed
+ * execution log for. Compound names are split on `+`, so "Power clean + Power
+ * jerk" contributes both `"power clean"` and `"power jerk"`. Used by the RMs
+ * screen to decide which RM groups get a "View progression" button.
+ */
+export async function fetchCompletedExerciseNameSet(
+	userId: string,
+): Promise<ServiceResult<Set<string>>> {
+	const supabase = getSupabaseClient();
+	const { data, error } = await supabase
+		.from('exercises')
+		.select(
+			`
+			name,
+			workouts!inner ( user_id ),
+			workout_execution_logs!inner ( id, execution_status )
+		`,
+		)
+		.eq('workouts.user_id', userId)
+		.eq('workout_execution_logs.execution_status', 'completed');
+
+	if (error) {
+		return { data: null, error: error.message };
+	}
+
+	const names = new Set<string>();
+	for (const row of (data ?? []) as Array<{ name: string }>) {
+		for (const seg of splitCompoundName(row.name).map(normalizeName)) {
+			if (seg) {
+				names.add(seg);
+			}
+		}
+	}
+	return { data: names, error: null };
+}

--- a/packages/peaktrack-services/src/index.ts
+++ b/packages/peaktrack-services/src/index.ts
@@ -9,3 +9,4 @@ export * from './repetitionMaximumService';
 export * from './workoutExecutionLogService';
 export * from './workoutRatingService';
 export * from './programService';
+export * from './exerciseProgressionService';

--- a/supabase/migrations/20260422000000_add_exercises_name_trgm_index.sql
+++ b/supabase/migrations/20260422000000_add_exercises_name_trgm_index.sql
@@ -1,0 +1,15 @@
+-- Trigram index on exercises.name for case-insensitive substring search.
+--
+-- The exercise-progression screen filters workouts server-side by
+-- `ilike '%target%'` against the exercise name so the client only decomposes
+-- a pre-filtered set (matching direct names and compounds that contain the
+-- target as a segment). Without an index this is a sequential scan over the
+-- user's full exercise history.
+--
+-- pg_trgm is bundled with every Supabase Postgres; this just enables it for
+-- our database if it isn't already.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_exercises_name_trgm
+    ON exercises USING gin (name gin_trgm_ops);


### PR DESCRIPTION
## Summary
- Adds `/exercise-progression?exerciseName=<name>` — a logs-only history chart (trend line over per-session volume + stacked rep-tile columns) that mirrors the program-progression look. Each RM group on `/repetition-maximums` gets a "View progression" primary button, rendered only when the user has at least one `execution_status = 'completed'` log for that exercise (direct match **or** as a compound segment). No prescribed/fallback data, no "not performed" points — just what was actually done.
- Emits **one chart point per completed log**, not per exercise: `start-workout.tsx` writes one log per `exercise_phases` row, so an exercise with warm-up + working-set phases shows as two adjacent columns on the same day. Rows are sorted `(workout_date, executed_at, logId)`.
- Compound-aware. `"Power clean + Power jerk"` with `compound_reps = [3, 1]` contributes to both the Power Clean and Power Jerk analyses; tiles for the analysed segment render bright, other segments faded. Volume uses **whole-set attribution** (`sets × compound_reps[0] × weight`) — for the worked example `3 × 3 × 50 = 450`.
- Shared tile/volume/normalize primitives extracted from `progressionLayout.ts` into new `progressionLayoutCore.ts`; program-progression now imports from there with no behaviour change. Existing 10 progression tests stay green.

## Data & performance
- Server-side query uses PostgREST embedded `!inner` joins (`workouts → exercises → workout_execution_logs`) with three filters: `user_id`, escaped `ilike '%<name>%'` on `exercises.name`, and `execution_status = 'completed'` on the nested log. Explicit column projection on the log — no `SELECT *`. 24-month rolling `workout_date` window by default.
- `ilike` user input is escaped (`%`, `_`, `\`) so an RM named `"50%"` doesn't turn into a LIKE wildcard.
- New migration `20260422000000_add_exercises_name_trgm_index.sql` enables `pg_trgm` and adds a GIN index on `exercises(name)` so the `ilike` pre-filter is index-backed. **Needs to be applied before merging to main** (or at least before the feature is expected to be fast on accounts with long exercise history). Correctness does not depend on it.

## Tests
- `apps/mobile/PeakTrack/lib/__tests__/exerciseProgressionLayout.test.ts` — 11 new tests covering: the compound worked example, tile highlighting for the analysed segment, non-conversion of the `weight_unit` suffix, `ilike` escape, compound-name splitting.
- Full repo test run: **235/235 passing**, 17 suites. Typecheck + lint clean (only pre-existing warnings).

## What's not in this PR
- Circuit-exercise decomposition (flagged in plan, out of scope).
- Estimated 1RM overlay on the progression chart (optional; easy to add later).
- The repo-wide RLS `(select auth.uid())` rewrite called out in the plan's security review — tracked as a separate concern.

## Related docs (local / gitignored)
- Plan: `docs/evil_empire/peakTrack/plans/exercise-progression-plan.md`
- Follow-up TODO unearthed during manual QA — a program imported with the program's own name as the per-exercise name (breaks matching here and program-RM percentage resolution elsewhere): `docs/evil_empire/peakTrack/todo/program-name-as-exercise-name.md`.

## Test plan
- [x] Apply the `pg_trgm` migration on the target env.
- [x] Open `/repetition-maximums` — only exercises with ≥1 completed log show the "View progression" button.
- [x] Tap through on a non-compound exercise (e.g. Back squat) — trend line + columns render; volume matches `sets × reps × weight`; weight label uses the stored number with the user's unit suffix (no conversion).
- [x] Tap through on a compound exercise (e.g. Power snatch when logged inside a `Power snatch + OHS`-style complex) — faded tiles appear for the non-analysed segment; legend row at the bottom surfaces.
- [x] Confirm a workout with both a warm-up and a working-set phase for the same exercise renders as two adjacent columns.
- [x] Confirm `'partial'` and `'skipped'` logs are not included.
- [x] Bottom nav: RMs tab stays active while on `/exercise-progression`.