### PR TITLE
fix(import): preserve multi-phase exercises in workout import

### DIFF
--- a/apps/mobile/PeakTrack/app/import-workout.tsx
+++ b/apps/mobile/PeakTrack/app/import-workout.tsx
@@ -82,9 +82,9 @@ function buildRmSourceNote(
 
 function isBlockReady(state: BlockState): boolean {
 	if (state.skipped) {return true;}
-	if (!state.block.parsed.isValid) {return false;}
+	if (!state.block.phases.every(p => p.isValid)) {return false;}
 	if (!state.name.trim()) {return false;}
-	if (state.block.parsed.needsRmLookup && state.rmWeight === undefined) {return false;}
+	if (state.block.phases.some(p => p.needsRmLookup) && state.rmWeight === undefined) {return false;}
 	return true;
 }
 
@@ -140,7 +140,7 @@ export default function ImportWorkoutScreen() {
 						notes: b.notes ?? '',
 						skipped: false,
 					};
-					if (b.parsed.needsRmLookup && b.suggestedName) {
+					if (b.phases.some(p => p.needsRmLookup) && b.suggestedName) {
 						const lookup = await lookupRm(user.id, b.suggestedName);
 						if (lookup.found) {
 							return { ...base, rmWeight: lookup.weight, rmSourceName: b.suggestedName };
@@ -219,7 +219,9 @@ export default function ImportWorkoutScreen() {
 			Alert.alert('Resolve all blocks', 'Each block must be skipped, parsed, or have its 1RM source set before saving.');
 			return;
 		}
-		const importable = blocks.filter(b => !b.skipped && b.block.parsed.isValid && b.name.trim());
+		const importable = blocks.filter(
+			b => !b.skipped && b.block.phases.every(p => p.isValid) && b.name.trim(),
+		);
 		if (importable.length === 0) {
 			Alert.alert('Nothing to import', 'All blocks were skipped or invalid.');
 			return;
@@ -253,51 +255,62 @@ export default function ImportWorkoutScreen() {
 					return;
 				}
 
-				// Resolve weights from the parsed data + any user-resolved RM.
-				const weightResult = await calculateWeightsFromParsedData(
-					user.id,
-					trimmedName,
-					state.block.parsed,
-					state.rmWeight,
-					state.rmSourceName,
-				);
-				if (!weightResult.success) {
-					setError(`Couldn't resolve weights for "${trimmedName}": ${weightResult.error ?? 'unknown error'}`);
-					return;
-				}
-
-				const { weight, weightMin, weightMax, weights: resolvedWeights, rmWeight, rmSourceName } = weightResult.weights;
-				const weightRange =
-					weightMin !== undefined && weightMax !== undefined ? { min: weightMin, max: weightMax } : undefined;
-
-				let finalParsed: ParsedSetData = state.block.parsed;
-				if (resolvedWeights) {
-					finalParsed = { ...finalParsed, weights: resolvedWeights };
-				}
-
-				// Combine user-edited notes with auto-generated RM source line.
 				const userNotes = state.notes.trim();
-				const rmSourceNote =
-					state.block.parsed.needsRmLookup && rmWeight
-						? buildRmSourceNote(state.block.parsed, rmWeight, rmSourceName ?? trimmedName, weightUnit)
-						: '';
-				const combinedNotes = [userNotes, rmSourceNote].filter(Boolean).join('\n');
-				if (combinedNotes) {
-					finalParsed = { ...finalParsed, notes: combinedNotes };
-				}
 
-				// For wave exercises with percentage weights, resolve to kg values
-				// (mirrors the special-case in useAddExercisePhase).
-				if (finalParsed.exerciseType === 'wave' && finalParsed.needsRmLookup && finalParsed.weights && rmWeight) {
-					const resolved = finalParsed.weights.map(pct => Math.round((rmWeight * pct) / 100));
-					finalParsed = { ...finalParsed, weights: resolved };
-				}
+				for (let phaseIdx = 0; phaseIdx < state.block.phases.length; phaseIdx++) {
+					const phase = state.block.phases[phaseIdx];
 
-				const phaseData = buildPhaseData(exercise.id, finalParsed, weight, weightRange);
-				const { error: phaseError } = await insertPhase(phaseData);
-				if (phaseError) {
-					setError(`Failed to insert phase for "${trimmedName}": ${phaseError}`);
-					return;
+					// Resolve weights from this phase + any user-resolved RM.
+					// `calculateWeightsFromParsedData` short-circuits when an rmWeight
+					// override is supplied, so phases 2+ reuse the resolved RM without
+					// hitting the DB again.
+					const weightResult = await calculateWeightsFromParsedData(
+						user.id,
+						trimmedName,
+						phase,
+						state.rmWeight,
+						state.rmSourceName,
+					);
+					if (!weightResult.success) {
+						setError(`Couldn't resolve weights for "${trimmedName}": ${weightResult.error ?? 'unknown error'}`);
+						return;
+					}
+
+					const { weight, weightMin, weightMax, weights: resolvedWeights, rmWeight, rmSourceName } = weightResult.weights;
+					const weightRange =
+						weightMin !== undefined && weightMax !== undefined ? { min: weightMin, max: weightMax } : undefined;
+
+					let finalParsed: ParsedSetData = phase;
+					if (resolvedWeights) {
+						finalParsed = { ...finalParsed, weights: resolvedWeights };
+					}
+
+					// User-edited block notes go on the first phase only; per-phase RM
+					// source line is generated for any phase whose weight came from a
+					// percentage so each phase shows its own resolved number.
+					const rmSourceNote =
+						phase.needsRmLookup && rmWeight
+							? buildRmSourceNote(phase, rmWeight, rmSourceName ?? trimmedName, weightUnit)
+							: '';
+					const blockNotes = phaseIdx === 0 ? userNotes : '';
+					const combinedNotes = [blockNotes, rmSourceNote].filter(Boolean).join('\n');
+					if (combinedNotes) {
+						finalParsed = { ...finalParsed, notes: combinedNotes };
+					}
+
+					// For wave exercises with percentage weights, resolve to kg values
+					// (mirrors the special-case in useAddExercisePhase).
+					if (finalParsed.exerciseType === 'wave' && finalParsed.needsRmLookup && finalParsed.weights && rmWeight) {
+						const resolved = finalParsed.weights.map(pct => Math.round((rmWeight * pct) / 100));
+						finalParsed = { ...finalParsed, weights: resolved };
+					}
+
+					const phaseData = buildPhaseData(exercise.id, finalParsed, weight, weightRange);
+					const { error: phaseError } = await insertPhase(phaseData);
+					if (phaseError) {
+						setError(`Failed to insert phase for "${trimmedName}": ${phaseError}`);
+						return;
+					}
 				}
 			}
 
@@ -421,8 +434,8 @@ interface BlockCardProps {
 
 function BlockCard({ state, weightUnit, onChangeName, onChangeNotes, onToggleSkip, onResolveRm }: BlockCardProps) {
 	const { block, skipped } = state;
-	const isUnparseable = !block.parsed.isValid;
-	const needsRm = block.parsed.needsRmLookup && state.rmWeight === undefined;
+	const isUnparseable = !block.phases.every(p => p.isValid);
+	const needsRm = block.phases.some(p => p.needsRmLookup) && state.rmWeight === undefined;
 
 	return (
 		<View style={[styles.card, skipped && styles.cardSkipped]}>
@@ -445,9 +458,11 @@ function BlockCard({ state, weightUnit, onChangeName, onChangeNotes, onToggleSki
 			</View>
 
 			{!isUnparseable ? (
-				<Text style={[styles.specSummary, skipped && styles.dimmed]}>
-					{summarizeSpec(block.parsed, state.rmWeight, weightUnit)}
-				</Text>
+				block.phases.map((phase, i) => (
+					<Text key={i} style={[styles.specSummary, skipped && styles.dimmed]}>
+						{summarizeSpec(phase, state.rmWeight, weightUnit)}
+					</Text>
+				))
 			) : (
 				<Text style={styles.unparseableText}>
 					Couldn't parse this block. Skip it, or go back and fix the pasted text.

--- a/apps/web/peaktrack-app/app/routes/_app.workouts.import.tsx
+++ b/apps/web/peaktrack-app/app/routes/_app.workouts.import.tsx
@@ -72,9 +72,9 @@ function summarize(parsed: ParsedSetData, rmWeight: number | undefined, unit: st
 
 function isReady(b: BlockState): boolean {
   if (b.skipped) return true;
-  if (!b.block.parsed.isValid) return false;
+  if (!b.block.phases.every((p) => p.isValid)) return false;
   if (!b.name.trim()) return false;
-  if (b.block.parsed.needsRmLookup && b.rmWeight === undefined) return false;
+  if (b.block.phases.some((p) => p.needsRmLookup) && b.rmWeight === undefined) return false;
   return true;
 }
 
@@ -126,7 +126,7 @@ function ImportWorkout() {
             notes: b.notes ?? '',
             skipped: false,
           };
-          if (b.parsed.needsRmLookup && b.suggestedName) {
+          if (b.phases.some((p) => p.needsRmLookup) && b.suggestedName) {
             const { data } = await lookupExactRm(user.id, b.suggestedName, 1);
             if (data?.weight) {
               return { ...base, rmWeight: data.weight, rmSourceName: b.suggestedName };
@@ -190,7 +190,7 @@ function ImportWorkout() {
       return;
     }
     const importable = blocks.filter(
-      (b) => !b.skipped && b.block.parsed.isValid && b.name.trim(),
+      (b) => !b.skipped && b.block.phases.every((p) => p.isValid) && b.name.trim(),
     );
     if (importable.length === 0) {
       setError('Nothing to import — all blocks were skipped or invalid.');
@@ -227,41 +227,54 @@ function ImportWorkout() {
           setError(`Failed to create exercise "${trimmedName}".`);
           return;
         }
-        const result = await resolveWeights({
-          userId: user.id,
-          exerciseName: trimmedName,
-          parsed: state.block.parsed,
-          weightUnit,
-          rmOverride:
-            state.rmWeight !== undefined
-              ? { weight: state.rmWeight, sourceName: state.rmSourceName }
-              : undefined,
-        });
-        if (result.kind === 'needs-rm') {
-          setError(`Couldn't resolve weights for "${trimmedName}".`);
-          return;
-        }
+
         const userNotes = state.notes.trim();
-        let finalParsed = result.finalParsed;
-        if (userNotes) {
-          const combined = [userNotes, finalParsed.notes].filter(Boolean).join('\n');
-          finalParsed = { ...finalParsed, notes: combined };
-        }
-        const { weights } = result;
-        const weightRange =
-          weights.weightMin !== undefined && weights.weightMax !== undefined
-            ? { min: weights.weightMin, max: weights.weightMax }
-            : undefined;
-        const phaseData = buildPhaseData(
-          exercise.id,
-          finalParsed,
-          weights.weight,
-          weightRange,
-        );
-        const { error: pErr } = await insertPhase(phaseData);
-        if (pErr) {
-          setError(`Failed to insert phase for "${trimmedName}": ${pErr}`);
-          return;
+
+        for (let phaseIdx = 0; phaseIdx < state.block.phases.length; phaseIdx++) {
+          const phase = state.block.phases[phaseIdx];
+
+          // Per-phase weight resolution. `resolveWeights` short-circuits on
+          // `rmOverride`, so phases 2+ don't trigger another DB lookup.
+          const result = await resolveWeights({
+            userId: user.id,
+            exerciseName: trimmedName,
+            parsed: phase,
+            weightUnit,
+            rmOverride:
+              state.rmWeight !== undefined
+                ? { weight: state.rmWeight, sourceName: state.rmSourceName }
+                : undefined,
+          });
+          if (result.kind === 'needs-rm') {
+            setError(`Couldn't resolve weights for "${trimmedName}".`);
+            return;
+          }
+
+          let finalParsed = result.finalParsed;
+          // User-edited block notes attach to the first phase only; per-phase
+          // RM source note (already on `finalParsed.notes`) stays on every
+          // phase that needs it.
+          if (phaseIdx === 0 && userNotes) {
+            const combined = [userNotes, finalParsed.notes].filter(Boolean).join('\n');
+            finalParsed = { ...finalParsed, notes: combined };
+          }
+
+          const { weights } = result;
+          const weightRange =
+            weights.weightMin !== undefined && weights.weightMax !== undefined
+              ? { min: weights.weightMin, max: weights.weightMax }
+              : undefined;
+          const phaseData = buildPhaseData(
+            exercise.id,
+            finalParsed,
+            weights.weight,
+            weightRange,
+          );
+          const { error: pErr } = await insertPhase(phaseData);
+          if (pErr) {
+            setError(`Failed to insert phase for "${trimmedName}": ${pErr}`);
+            return;
+          }
         }
       }
 
@@ -316,8 +329,9 @@ function ImportWorkout() {
             Review {blocks.length} block{blocks.length === 1 ? '' : 's'}. Resolve any "1RM needed" chips, then save.
           </Text>
           {blocks.map((state, idx) => {
-            const unparseable = !state.block.parsed.isValid;
-            const needsRm = state.block.parsed.needsRmLookup && state.rmWeight === undefined;
+            const unparseable = !state.block.phases.every((p) => p.isValid);
+            const needsRm =
+              state.block.phases.some((p) => p.needsRmLookup) && state.rmWeight === undefined;
             return (
               <Card
                 key={idx}
@@ -345,7 +359,11 @@ function ImportWorkout() {
                     Couldn't parse this block. Skip it, or go back and fix the pasted text.
                   </Text>
                 ) : (
-                  <Text variant="body-sm">{summarize(state.block.parsed, state.rmWeight, weightUnit)}</Text>
+                  state.block.phases.map((phase, phaseIdx) => (
+                    <Text key={phaseIdx} variant="body-sm">
+                      {summarize(phase, state.rmWeight, weightUnit)}
+                    </Text>
+                  ))
                 )}
                 {!unparseable ? (
                   <Input

--- a/docs/evil_empire/peakTrack/plans/fix-workout-import-multi-phase-plan.md
+++ b/docs/evil_empire/peakTrack/plans/fix-workout-import-multi-phase-plan.md
@@ -1,0 +1,161 @@
+# Fix multi-phase parsing in workout import
+
+## Context
+
+Pasting a workout into the import flow collapses multi-phase exercises. When
+an exercise has more than one set-spec line (different sets/reps/weights for
+working-up sets, e.g. an Olympic-lifting complex), only the FIRST spec line
+becomes a phase; every subsequent line — including legitimate further specs —
+gets dumped into the notes field.
+
+User-reported case (one logical exercise, three phases):
+
+```
+Power snatch + hang snatch
+1 x 3 + 1 @55-60%
+2 x 2 + 1 @65%
+5 x 1 + 1 @70-75%
+60% of Power Snatch 1RM (65kg)
+```
+
+Expected: ONE exercise with THREE phases, plus the trailing line as notes.
+Actual: ONE exercise with ONE phase (the `55-60%` line); the other two specs
+plus the RM line are concatenated into `notes`.
+
+### Root cause
+
+`packages/parsers/src/workoutTextPreprocessor.ts:116`
+```ts
+const setSpecIdx = lines.findIndex(l => SET_SPEC_REGEX.test(l));
+```
+finds only the FIRST spec line. Lines after it (line 128) are joined into
+`notesText` regardless of whether they themselves match the spec regex.
+
+### Why this approach
+
+Three working-up sets belong to one exercise, not three. The data model
+already supports many `exercise_phases` per exercise (mobile UI maps
+`exercise_id → ExercisePhase[]`). The fix should preserve "one block = one
+exercise" but allow each block to carry multiple parsed phases. Splitting
+into N blocks would force the user through N name fields, N skip toggles,
+and N RM resolutions for the same lift — wrong UX.
+
+## Approach: multi-phase per block
+
+Reshape the parser output so one `ParsedWorkoutBlock` carries an array of
+`ParsedSetData`. Update the two import screens (mobile + web) to render one
+summary row per phase and to insert one DB row per phase under a single
+exercise.
+
+## Files to modify
+
+### 1. `packages/parsers/src/workoutTextPreprocessor.ts`
+
+- Change `PreprocessedBlock.setSpecLine: string` → `setSpecLines: string[]`.
+- In `processBlock` multi-line branch:
+  - Collect ALL indices where `SET_SPEC_REGEX.test(line)` matches.
+  - Lines BEFORE the first spec → `suggestedName`.
+  - Each matching spec line → `setSpecLines[i]`, each rewritten via
+    `rewriteSetSpec`.
+  - Non-spec lines AFTER the first spec → `notesText` (joined with `\n`).
+    This includes lines between specs (rare in practice; documented as
+    block-level notes).
+  - If no spec lines → `parseError: 'no_set_spec'`, `setSpecLines: []`.
+- Single-line branch: produce `setSpecLines: [rewritten]` for the success
+  paths, `[]` for the no-spec path. Behavior unchanged.
+
+### 2. `packages/parsers/src/index.ts`
+
+- Change `ParsedWorkoutBlock.parsed: ParsedSetData` → `phases: ParsedSetData[]`.
+- Update `parseWorkoutText`:
+  - Map each `setSpecLines[i]` through `parseSetInput` → `phases`.
+  - For `parseError === 'no_set_spec'`, emit a single-element `phases`
+    containing `invalidResult(...)` (preserves "one block = one card" so
+    the UI can still render it as unparseable).
+  - `missing` aggregates: `'unparseable'` if any phase is invalid;
+    `'rmSource'` if any phase has `needsRmLookup`.
+
+### 3. Parser tests
+
+`packages/parsers/__tests__/workoutTextPreprocessor.test.ts`:
+- Rename assertions from `setSpecLine` → `setSpecLines`.
+- Add cases:
+  - User's Power Snatch input → 3 spec lines, 1 trailing notes line.
+  - Two specs only, no notes → 2 spec lines, no `notesText`.
+  - Spec / note / spec → 2 spec lines, 1 note line.
+  - Single-spec block (existing) → still single-element array.
+
+`packages/parsers/__tests__/parseWorkoutText.test.ts`:
+- Rename `block.parsed` → `block.phases[0]` throughout existing tests.
+- Add a multi-phase test for the Power Snatch input.
+
+### 4. `apps/mobile/PeakTrack/app/import-workout.tsx`
+
+- Update `isBlockReady`: use `phases.every(p => p.isValid)` and
+  `phases.some(p => p.needsRmLookup)`.
+- Update `handleParse`: RM eager-lookup uses the block's name once; result
+  is shared across all phases.
+- Update `handleSave`:
+  - After `createExercise`, loop over `state.block.phases`. For each phase:
+    1. Call `calculateWeightsFromParsedData(...)` passing
+       `state.rmWeight` / `state.rmSourceName` as overrides — the hook
+       already short-circuits when `rmWeightOverride` is set, so no extra
+       DB queries are made for phases 2+.
+    2. Build `finalParsed` per phase. Attach the user-edited block-level
+       `state.notes` to phase[0] only; auto-generated `buildRmSourceNote`
+       attaches per phase that has `needsRmLookup`.
+    3. Apply the wave special-case per phase.
+    4. `await insertPhase(buildPhaseData(...))`. Sequential awaits preserve
+       insertion order; phases are ordered by `created_at` (no
+       `phase_order` column exists in `exercise_phases`).
+- Update `BlockCard` to render one `summarizeSpec` per phase (a small list,
+  not a single line). `summarizeSpec` is unchanged — call it per phase.
+
+### 5. `apps/web/peaktrack-app/app/routes/_app.workouts.import.tsx`
+
+Mirror the mobile changes:
+- Update `isReady`.
+- Update `handleParse` block-resolution.
+- Update `handleSave` to loop over `phases`, calling `resolveWeights({ ...,
+  parsed: phase, rmOverride })` for each. Same per-phase notes/RM-source-
+  note wiring as mobile.
+- Update the BlockCard equivalent to render one summary row per phase via
+  `summarize`.
+- `apps/web/peaktrack-app/app/lib/rm-lookup.ts` already takes a single
+  `parsed: ParsedSetData` and accepts `rmOverride`; no changes needed
+  inside the file — only the call sites loop.
+
+## Reused utilities
+
+- `parseSetInput` (`packages/parsers/src/index.ts`) — unchanged; called per
+  spec line.
+- `buildPhaseData` (`packages/peaktrack-services/src/buildPhaseData.ts`) —
+  unchanged; called per phase.
+- `insertPhase` (`@evil-empire/peaktrack-services`) — unchanged; called per
+  phase.
+- `calculateWeightsFromParsedData` (`useRmLookup.ts`) — unchanged;
+  short-circuit on `rmWeightOverride` lets us reuse one RM across phases.
+- `resolveWeights` (`apps/web/peaktrack-app/app/lib/rm-lookup.ts`) —
+  unchanged; same `rmOverride` short-circuit on the web side.
+- `buildRmSourceNote` (mobile `import-workout.tsx`) — unchanged; called per
+  phase.
+
+## Verification
+
+1. **Unit tests**: `pnpm test --filter=@evil-empire/parsers` — preprocessor
+   and `parseWorkoutText` suites should both pass, including the new
+   multi-spec cases.
+2. **Type check**: `pnpm typecheck` — surfaces every leftover `block.parsed`
+   reference if any are missed.
+3. **Mobile end-to-end** (`pnpm dev:mobile`):
+   - Open Import workout, paste the Power Snatch sample, parse.
+   - Review screen: ONE card titled "Power snatch + hang snatch" showing
+     three spec rows. Notes field prefilled with `60% of Power Snatch 1RM
+     (65kg)`.
+   - Resolve a Power Snatch 1RM (or pre-create one in RMs).
+   - Save. Open the workout: one exercise with three phases, weights
+     resolved per phase percentage; phase 1 carries the user notes.
+4. **Web end-to-end** (`pnpm dev:web`): same flow, same expectations.
+5. **Regression check**: re-import the existing 4-block reference paste
+   from `parseWorkoutText.test.ts` to confirm single-spec blocks still
+   produce one phase each with notes attached correctly.

--- a/packages/parsers/__tests__/parseWorkoutText.test.ts
+++ b/packages/parsers/__tests__/parseWorkoutText.test.ts
@@ -11,10 +11,11 @@ describe('parseWorkoutText', () => {
 			const [block] = parseWorkoutText('Squat\n5 x 5 @100kg');
 
 			expect(block.suggestedName).toBe('Squat');
-			expect(block.parsed.isValid).toBe(true);
-			expect(block.parsed.sets).toBe(5);
-			expect(block.parsed.reps).toBe(5);
-			expect(block.parsed.weight).toBe(100);
+			expect(block.phases).toHaveLength(1);
+			expect(block.phases[0].isValid).toBe(true);
+			expect(block.phases[0].sets).toBe(5);
+			expect(block.phases[0].reps).toBe(5);
+			expect(block.phases[0].weight).toBe(100);
 			expect(block.missing).toEqual([]);
 			expect(block.notes).toBeUndefined();
 		});
@@ -22,10 +23,10 @@ describe('parseWorkoutText', () => {
 		it('flags a percentage-based block with missing: ["rmSource"]', () => {
 			const [block] = parseWorkoutText('Snatch pull + hang power snatch\n8 x 3+3 @70-75%');
 
-			expect(block.parsed.isValid).toBe(true);
-			expect(block.parsed.needsRmLookup).toBe(true);
-			expect(block.parsed.weightMinPercentage).toBe(70);
-			expect(block.parsed.weightMaxPercentage).toBe(75);
+			expect(block.phases[0].isValid).toBe(true);
+			expect(block.phases[0].needsRmLookup).toBe(true);
+			expect(block.phases[0].weightMinPercentage).toBe(70);
+			expect(block.phases[0].weightMaxPercentage).toBe(75);
 			expect(block.missing).toEqual(['rmSource']);
 		});
 
@@ -34,10 +35,10 @@ describe('parseWorkoutText', () => {
 				'High hang muscle snatch + push press BTN + OHS\n4 x 3+3+3 @light weight\npause in lockout',
 			);
 
-			expect(block.parsed.isValid).toBe(true);
-			expect(block.parsed.weightPercentage).toBe(60);
-			expect(block.parsed.compoundReps).toEqual([3, 3, 3]);
-			expect(block.parsed.needsRmLookup).toBe(true);
+			expect(block.phases[0].isValid).toBe(true);
+			expect(block.phases[0].weightPercentage).toBe(60);
+			expect(block.phases[0].compoundReps).toEqual([3, 3, 3]);
+			expect(block.phases[0].needsRmLookup).toBe(true);
 			expect(block.notes).toBe('pause in lockout');
 			expect(block.missing).toEqual(['rmSource']);
 		});
@@ -45,8 +46,8 @@ describe('parseWorkoutText', () => {
 		it('strips "of 1RM" suffix and parses cleanly', () => {
 			const [block] = parseWorkoutText('Snatch grip DL with pause\n4 x 5 @95% of 1RM\npause at knee for 3 sec');
 
-			expect(block.parsed.isValid).toBe(true);
-			expect(block.parsed.weightPercentage).toBe(95);
+			expect(block.phases[0].isValid).toBe(true);
+			expect(block.phases[0].weightPercentage).toBe(95);
 			expect(block.notes).toBe('pause at knee for 3 sec');
 			expect(block.missing).toEqual(['rmSource']);
 		});
@@ -56,7 +57,7 @@ describe('parseWorkoutText', () => {
 
 			// "this is not a valid spec" doesn't match the set-spec regex either,
 			// so the preprocessor surfaces it as parseError: 'no_set_spec'.
-			expect(block.parsed.isValid).toBe(false);
+			expect(block.phases[0].isValid).toBe(false);
 			expect(block.missing).toEqual(['unparseable']);
 		});
 
@@ -64,7 +65,7 @@ describe('parseWorkoutText', () => {
 			// "5 x 5" matches the set-spec regex but parseSetInput rejects it (missing weight).
 			const [block] = parseWorkoutText('Squat\n5 x 5');
 
-			expect(block.parsed.isValid).toBe(false);
+			expect(block.phases[0].isValid).toBe(false);
 			expect(block.missing).toEqual(['unparseable']);
 		});
 
@@ -72,6 +73,56 @@ describe('parseWorkoutText', () => {
 			const raw = 'Squat\n5 x 5 @100kg';
 			const [block] = parseWorkoutText(raw);
 			expect(block.rawText).toBe(raw);
+		});
+	});
+
+	describe('multi-phase exercise', () => {
+		it('returns one phase per spec line for an Olympic-lifting complex', () => {
+			const raw = [
+				'Power snatch + hang snatch',
+				'1 x 3 + 1 @55-60%',
+				'2 x 2 + 1 @65%',
+				'5 x 1 + 1 @70-75%',
+				'60% of Power Snatch 1RM (65kg)',
+			].join('\n');
+
+			const [block] = parseWorkoutText(raw);
+
+			expect(block.suggestedName).toBe('Power snatch + hang snatch');
+			expect(block.phases).toHaveLength(3);
+
+			expect(block.phases[0].isValid).toBe(true);
+			expect(block.phases[0].sets).toBe(1);
+			expect(block.phases[0].compoundReps).toEqual([3, 1]);
+			expect(block.phases[0].weightMinPercentage).toBe(55);
+			expect(block.phases[0].weightMaxPercentage).toBe(60);
+			expect(block.phases[0].needsRmLookup).toBe(true);
+
+			expect(block.phases[1].isValid).toBe(true);
+			expect(block.phases[1].sets).toBe(2);
+			expect(block.phases[1].compoundReps).toEqual([2, 1]);
+			expect(block.phases[1].weightPercentage).toBe(65);
+			expect(block.phases[1].needsRmLookup).toBe(true);
+
+			expect(block.phases[2].isValid).toBe(true);
+			expect(block.phases[2].sets).toBe(5);
+			expect(block.phases[2].compoundReps).toEqual([1, 1]);
+			expect(block.phases[2].weightMinPercentage).toBe(70);
+			expect(block.phases[2].weightMaxPercentage).toBe(75);
+			expect(block.phases[2].needsRmLookup).toBe(true);
+
+			expect(block.notes).toBe('60% of Power Snatch 1RM (65kg)');
+			expect(block.missing).toEqual(['rmSource']);
+		});
+
+		it('aggregates "unparseable" if any phase fails', () => {
+			const raw = ['Squat', '5 x 5 @100kg', 'broken spec line still has 5 x 5'].join('\n');
+			const [block] = parseWorkoutText(raw);
+
+			expect(block.phases).toHaveLength(2);
+			expect(block.phases[0].isValid).toBe(true);
+			expect(block.phases[1].isValid).toBe(false);
+			expect(block.missing).toEqual(['unparseable']);
 		});
 	});
 
@@ -99,27 +150,27 @@ describe('parseWorkoutText', () => {
 			const [header, ex1, ex2, ex3] = blocks;
 
 			expect(header.missing).toEqual(['unparseable']);
-			expect(header.parsed.isValid).toBe(false);
+			expect(header.phases[0].isValid).toBe(false);
 
 			expect(ex1.suggestedName).toBe('High hang muscle snatch + push press BTN + OHS');
-			expect(ex1.parsed.isValid).toBe(true);
-			expect(ex1.parsed.weightPercentage).toBe(60);
-			expect(ex1.parsed.compoundReps).toEqual([3, 3, 3]);
+			expect(ex1.phases[0].isValid).toBe(true);
+			expect(ex1.phases[0].weightPercentage).toBe(60);
+			expect(ex1.phases[0].compoundReps).toEqual([3, 3, 3]);
 			expect(ex1.notes).toBe('pause in lockout of each push press & in the bottom of OHS');
 			expect(ex1.missing).toEqual(['rmSource']);
 
 			expect(ex2.suggestedName).toBe('Snatch pull + hang power snatch');
-			expect(ex2.parsed.isValid).toBe(true);
-			expect(ex2.parsed.weightMinPercentage).toBe(70);
-			expect(ex2.parsed.weightMaxPercentage).toBe(75);
-			expect(ex2.parsed.compoundReps).toEqual([3, 3]);
+			expect(ex2.phases[0].isValid).toBe(true);
+			expect(ex2.phases[0].weightMinPercentage).toBe(70);
+			expect(ex2.phases[0].weightMaxPercentage).toBe(75);
+			expect(ex2.phases[0].compoundReps).toEqual([3, 3]);
 			expect(ex2.missing).toEqual(['rmSource']);
 
 			expect(ex3.suggestedName).toBe('Snatch grip DL with pause');
-			expect(ex3.parsed.isValid).toBe(true);
-			expect(ex3.parsed.sets).toBe(4);
-			expect(ex3.parsed.reps).toBe(5);
-			expect(ex3.parsed.weightPercentage).toBe(95);
+			expect(ex3.phases[0].isValid).toBe(true);
+			expect(ex3.phases[0].sets).toBe(4);
+			expect(ex3.phases[0].reps).toBe(5);
+			expect(ex3.phases[0].weightPercentage).toBe(95);
 			expect(ex3.notes).toBe('pause at knee for 3 sec');
 			expect(ex3.missing).toEqual(['rmSource']);
 		});

--- a/packages/parsers/__tests__/workoutTextPreprocessor.test.ts
+++ b/packages/parsers/__tests__/workoutTextPreprocessor.test.ts
@@ -22,7 +22,7 @@ describe('preprocessWorkoutText', () => {
 			const [block] = preprocessWorkoutText(raw);
 
 			expect(block.suggestedName).toBe('Snatch grip DL with pause');
-			expect(block.setSpecLine).toBe('4x 5 @95% of 1RM');
+			expect(block.setSpecLines).toEqual(['4x 5 @95% of 1RM']);
 			expect(block.notesText).toBe('pause at knee for 3 sec');
 			expect(block.parseError).toBeUndefined();
 		});
@@ -37,13 +37,13 @@ describe('preprocessWorkoutText', () => {
 			const [block] = preprocessWorkoutText(raw);
 
 			expect(block.suggestedName).toBe('High hang muscle snatch + push press BTN + OHS');
-			expect(block.setSpecLine).toBe('4 x 3+3+3 @60%');
+			expect(block.setSpecLines).toEqual(['4 x 3+3+3 @60%']);
 			expect(block.notesText).toBe('pause in lockout of each push press & in the bottom of OHS');
 		});
 
 		it('also rewrites bare "@light" without "weight"', () => {
 			const [block] = preprocessWorkoutText('Squat\n5 x 5 @light');
-			expect(block.setSpecLine).toBe('5 x 5 @60%');
+			expect(block.setSpecLines).toEqual(['5 x 5 @60%']);
 		});
 
 		it('preserves a percentage range exactly', () => {
@@ -51,7 +51,7 @@ describe('preprocessWorkoutText', () => {
 			const [block] = preprocessWorkoutText(raw);
 
 			expect(block.suggestedName).toBe('Snatch pull + hang power snatch');
-			expect(block.setSpecLine).toBe('8 x 3+3 @70-75%');
+			expect(block.setSpecLines).toEqual(['8 x 3+3 @70-75%']);
 			expect(block.notesText).toBeUndefined();
 		});
 
@@ -74,35 +74,87 @@ describe('preprocessWorkoutText', () => {
 		});
 	});
 
+	describe('multi-spec block (one exercise, multiple phases)', () => {
+		it('captures every spec line as a phase and trailing notes separately', () => {
+			const raw = [
+				'Power snatch + hang snatch',
+				'1 x 3 + 1 @55-60%',
+				'2 x 2 + 1 @65%',
+				'5 x 1 + 1 @70-75%',
+				'60% of Power Snatch 1RM (65kg)',
+			].join('\n');
+
+			const [block] = preprocessWorkoutText(raw);
+
+			expect(block.suggestedName).toBe('Power snatch + hang snatch');
+			expect(block.setSpecLines).toEqual([
+				'1 x 3 + 1 @55-60%',
+				'2 x 2 + 1 @65%',
+				'5 x 1 + 1 @70-75%',
+			]);
+			expect(block.notesText).toBe('60% of Power Snatch 1RM (65kg)');
+			expect(block.parseError).toBeUndefined();
+		});
+
+		it('captures back-to-back specs with no notes', () => {
+			const raw = ['Clean', '3 x 2 @70%', '2 x 1 @80%'].join('\n');
+			const [block] = preprocessWorkoutText(raw);
+
+			expect(block.suggestedName).toBe('Clean');
+			expect(block.setSpecLines).toEqual(['3 x 2 @70%', '2 x 1 @80%']);
+			expect(block.notesText).toBeUndefined();
+		});
+
+		it('collapses lines between specs into block-level notes', () => {
+			const raw = [
+				'Snatch',
+				'3 x 2 @70%',
+				'pause at knee',
+				'2 x 1 @85%',
+			].join('\n');
+
+			const [block] = preprocessWorkoutText(raw);
+
+			expect(block.setSpecLines).toEqual(['3 x 2 @70%', '2 x 1 @85%']);
+			expect(block.notesText).toBe('pause at knee');
+		});
+
+		it('rewrites tokens on every spec line independently', () => {
+			const raw = ['Squat', '3 x 5 @light weight', '2 x 3 @light'].join('\n');
+			const [block] = preprocessWorkoutText(raw);
+			expect(block.setSpecLines).toEqual(['3 x 5 @60%', '2 x 3 @60%']);
+		});
+	});
+
 	describe('single-line block', () => {
 		it('splits inline "name — spec" form on em dash', () => {
 			const [block] = preprocessWorkoutText('Snatch grip DL — 4 x 5 @95%');
 			expect(block.suggestedName).toBe('Snatch grip DL');
-			expect(block.setSpecLine).toBe('4 x 5 @95%');
+			expect(block.setSpecLines).toEqual(['4 x 5 @95%']);
 		});
 
 		it('splits inline "name: spec" form on colon', () => {
 			const [block] = preprocessWorkoutText('Squat: 5 x 5 @100kg');
 			expect(block.suggestedName).toBe('Squat');
-			expect(block.setSpecLine).toBe('5 x 5 @100kg');
+			expect(block.setSpecLines).toEqual(['5 x 5 @100kg']);
 		});
 
 		it('splits inline "name - spec" form on hyphen with surrounding spaces', () => {
 			const [block] = preprocessWorkoutText('Squat - 5 x 5 @100kg');
 			expect(block.suggestedName).toBe('Squat');
-			expect(block.setSpecLine).toBe('5 x 5 @100kg');
+			expect(block.setSpecLines).toEqual(['5 x 5 @100kg']);
 		});
 
 		it('does NOT split on hyphen without spaces (preserves "T-bar row")', () => {
 			const [block] = preprocessWorkoutText('T-bar row\n4 x 8 @60kg');
 			expect(block.suggestedName).toBe('T-bar row');
-			expect(block.setSpecLine).toBe('4 x 8 @60kg');
+			expect(block.setSpecLines).toEqual(['4 x 8 @60kg']);
 		});
 
 		it('treats a bare set-spec line as a block with empty name', () => {
 			const [block] = preprocessWorkoutText('4 x 5 @100kg');
 			expect(block.suggestedName).toBe('');
-			expect(block.setSpecLine).toBe('4 x 5 @100kg');
+			expect(block.setSpecLines).toEqual(['4 x 5 @100kg']);
 			expect(block.parseError).toBeUndefined();
 		});
 
@@ -110,7 +162,7 @@ describe('preprocessWorkoutText', () => {
 			const [block] = preprocessWorkoutText('Snatch WORKOUT');
 			expect(block.parseError).toBe('no_set_spec');
 			expect(block.suggestedName).toBe('Snatch WORKOUT');
-			expect(block.setSpecLine).toBe('');
+			expect(block.setSpecLines).toEqual([]);
 		});
 	});
 
@@ -169,21 +221,21 @@ describe('preprocessWorkoutText', () => {
 
 			expect(ex1).toMatchObject({
 				suggestedName: 'High hang muscle snatch + push press BTN + OHS',
-				setSpecLine: '4 x 3+3+3 @60%',
+				setSpecLines: ['4 x 3+3+3 @60%'],
 				notesText: 'pause in lockout of each push press & in the bottom of OHS',
 			});
 			expect(ex1.parseError).toBeUndefined();
 
 			expect(ex2).toMatchObject({
 				suggestedName: 'Snatch pull + hang power snatch',
-				setSpecLine: '8 x 3+3 @70-75%',
+				setSpecLines: ['8 x 3+3 @70-75%'],
 			});
 			expect(ex2.notesText).toBeUndefined();
 			expect(ex2.parseError).toBeUndefined();
 
 			expect(ex3).toMatchObject({
 				suggestedName: 'Snatch grip DL with pause',
-				setSpecLine: '4 x 5 @95% of 1RM',
+				setSpecLines: ['4 x 5 @95% of 1RM'],
 				notesText: 'pause at knee for 3 sec',
 			});
 			expect(ex3.parseError).toBeUndefined();

--- a/packages/parsers/src/index.ts
+++ b/packages/parsers/src/index.ts
@@ -256,17 +256,21 @@ export type WorkoutBlockMissing = 'unparseable' | 'rmSource';
 
 /**
  * One imported exercise: the preprocessor's name/notes guess, the parser's
- * structured output, and a checklist of what (if anything) is still missing
- * before the block can be saved as an `ExercisePhase`.
+ * structured output for each phase, and a checklist of what (if anything) is
+ * still missing before the block can be saved as one or more `ExercisePhase`s.
+ *
+ * `phases` always has at least one entry. A block whose preprocessor flagged
+ * `no_set_spec` carries a single invalid `ParsedSetData` so the UI can render
+ * it as an unparseable card.
  */
 export interface ParsedWorkoutBlock {
 	/** Original block text exactly as the user pasted it. */
 	rawText: string;
 	/** Best-guess exercise name from the preprocessor. May be empty. */
 	suggestedName: string;
-	/** Result of feeding `setSpecLine` into `parseSetInput`. `isValid: false` on failure. */
-	parsed: ParsedSetData;
-	/** Notes the preprocessor extracted from lines after the set-spec. */
+	/** One parsed phase per set-spec line found in the block. Always non-empty. */
+	phases: ParsedSetData[];
+	/** Notes the preprocessor extracted from non-spec lines after the first spec. */
 	notes?: string;
 	/** Information still required before the block can be saved. */
 	missing: WorkoutBlockMissing[];
@@ -278,31 +282,32 @@ export interface ParsedWorkoutBlock {
  * High-level flow:
  * 1. {@link preprocessWorkoutText} splits the input into per-exercise blocks
  *    and rewrites tokens (`@light weight` → `@60%`).
- * 2. Each block's set-spec line is fed through {@link parseSetInput}.
- * 3. A `missing` checklist is computed from the parser result so the UI can
- *    drive any follow-up prompts (RM picker, raw-edit fallback).
+ * 2. Each block's set-spec lines are fed through {@link parseSetInput}, one
+ *    `ParsedSetData` per phase.
+ * 3. A `missing` checklist is computed across all phases so the UI can drive
+ *    follow-up prompts (RM picker, raw-edit fallback) at the block level.
  *
  * Returns `[]` for empty input.
  */
 export function parseWorkoutText(raw: string): ParsedWorkoutBlock[] {
 	return preprocessWorkoutText(raw).map(block => {
-		const parsed =
+		const phases: ParsedSetData[] =
 			block.parseError === 'no_set_spec'
-				? invalidResult('No sets x reps line found in this block.')
-				: parseSetInput(block.setSpecLine);
+				? [invalidResult('No sets x reps line found in this block.')]
+				: block.setSpecLines.map(line => parseSetInput(line));
 
 		const missing: WorkoutBlockMissing[] = [];
-		if (!parsed.isValid) {
+		if (phases.some(p => !p.isValid)) {
 			missing.push('unparseable');
 		}
-		if (parsed.needsRmLookup) {
+		if (phases.some(p => p.needsRmLookup)) {
 			missing.push('rmSource');
 		}
 
 		return {
 			rawText: block.rawText,
 			suggestedName: block.suggestedName,
-			parsed,
+			phases,
 			...(block.notesText !== undefined && { notes: block.notesText }),
 			missing,
 		};

--- a/packages/parsers/src/workoutTextPreprocessor.ts
+++ b/packages/parsers/src/workoutTextPreprocessor.ts
@@ -22,12 +22,22 @@ export interface PreprocessedBlock {
 	/** Best guess at the exercise name. May be empty if no name line was present. */
 	suggestedName: string;
 	/**
-	 * The set-spec line, ready to feed to `parseSetInput`.
+	 * The set-spec lines for this block, ready to feed to `parseSetInput`.
 	 * Token rewrites already applied (e.g. `@light weight` → `@60%`).
-	 * Empty string when `parseError === 'no_set_spec'`.
+	 *
+	 * A block may carry multiple specs when the same exercise has working-up
+	 * sets at different intensities (e.g. an Olympic-lifting complex with
+	 * `1 x 3+1 @55-60%` then `2 x 2+1 @65%` then `5 x 1+1 @70-75%`). Each
+	 * entry parses into its own phase.
+	 *
+	 * Empty array when `parseError === 'no_set_spec'`.
 	 */
-	setSpecLine: string;
-	/** Lines after the set-spec, joined with `\n`. Undefined when none. */
+	setSpecLines: string[];
+	/**
+	 * Block-level notes — non-spec lines that appear after the first spec.
+	 * Lines that fall between specs collapse into the same notes string.
+	 * Undefined when no such lines are present.
+	 */
 	notesText?: string;
 	/** Set when no set-spec line could be detected in this block. */
 	parseError?: 'no_set_spec';
@@ -92,7 +102,7 @@ function processBlock(blockText: string): PreprocessedBlock {
 			return {
 				rawText: blockText,
 				suggestedName: stripTrailingSeparator(inline.name),
-				setSpecLine: rewriteSetSpec(inline.spec),
+				setSpecLines: [rewriteSetSpec(inline.spec)],
 			};
 		}
 
@@ -100,39 +110,48 @@ function processBlock(blockText: string): PreprocessedBlock {
 			return {
 				rawText: blockText,
 				suggestedName: '',
-				setSpecLine: rewriteSetSpec(line),
+				setSpecLines: [rewriteSetSpec(line)],
 			};
 		}
 
 		return {
 			rawText: blockText,
 			suggestedName: line,
-			setSpecLine: '',
+			setSpecLines: [],
 			parseError: 'no_set_spec',
 		};
 	}
 
-	// Multi-line: find the first line that looks like a set spec.
-	const setSpecIdx = lines.findIndex(l => SET_SPEC_REGEX.test(l));
+	// Multi-line: collect every line that looks like a set spec.
+	const specIndices: number[] = [];
+	lines.forEach((l, i) => {
+		if (SET_SPEC_REGEX.test(l)) {
+			specIndices.push(i);
+		}
+	});
 
-	if (setSpecIdx === -1) {
+	if (specIndices.length === 0) {
 		return {
 			rawText: blockText,
 			suggestedName: lines.join(' '),
-			setSpecLine: '',
+			setSpecLines: [],
 			parseError: 'no_set_spec',
 		};
 	}
 
-	const nameLines = lines.slice(0, setSpecIdx);
-	const noteLines = lines.slice(setSpecIdx + 1);
+	const firstSpecIdx = specIndices[0];
+	const specIndexSet = new Set(specIndices);
+	const nameLines = lines.slice(0, firstSpecIdx);
+	const noteLines = lines
+		.slice(firstSpecIdx + 1)
+		.filter((_, i) => !specIndexSet.has(firstSpecIdx + 1 + i));
 	const suggestedName = stripTrailingSeparator(nameLines.join(' '));
 	const notesText = noteLines.length > 0 ? noteLines.join('\n') : undefined;
 
 	return {
 		rawText: blockText,
 		suggestedName,
-		setSpecLine: rewriteSetSpec(lines[setSpecIdx]),
+		setSpecLines: specIndices.map(i => rewriteSetSpec(lines[i])),
 		...(notesText !== undefined && { notesText }),
 	};
 }
@@ -141,14 +160,17 @@ function processBlock(blockText: string): PreprocessedBlock {
  * Split free-form pasted workout text into one block per exercise.
  *
  * Block boundary heuristic: blank line(s). Within a block:
- * - Find the first line containing a sets-x-reps pattern → set-spec line.
- * - Lines before it → suggestedName (joined with spaces).
- * - Lines after it → notesText (joined with newlines).
- * - Apply token rewrites to the set-spec line (e.g. `@light weight` → `@60%`).
+ * - Collect every line containing a sets-x-reps pattern → `setSpecLines`.
+ *   Multiple specs map to multiple phases of the same exercise (e.g. an
+ *   Olympic complex with three working-up sets).
+ * - Lines BEFORE the first spec → suggestedName (joined with spaces).
+ * - Non-spec lines AFTER the first spec → notesText (joined with newlines).
+ *   Lines between specs collapse into the same notes string.
+ * - Apply token rewrites to each spec line (e.g. `@light weight` → `@60%`).
  *
  * Blocks that contain no set-spec (e.g. workout headers like "Snatch WORKOUT")
- * are returned with `parseError: 'no_set_spec'` so the UI can either skip them
- * or surface them for manual editing.
+ * are returned with `parseError: 'no_set_spec'` and `setSpecLines: []` so the
+ * UI can either skip them or surface them for manual editing.
  *
  * @param raw - The full pasted text, possibly containing multiple blocks.
  * @returns One `PreprocessedBlock` per non-empty block, in source order. Returns


### PR DESCRIPTION
## Summary

- Importing a pasted exercise with several set-spec lines (e.g. `1 x 3+1 @55-60%` / `2 x 2+1 @65%` / `5 x 1+1 @70-75%`) collapsed into a single phase — the first spec became a phase and every subsequent line, including legitimate further specs, was dumped into notes.
- The preprocessor now collects every set-spec line in a block. `ParsedWorkoutBlock` carries `phases: ParsedSetData[]` instead of `parsed: ParsedSetData`, and the mobile + web import screens render and save one phase per spec.
- One exercise → many `exercise_phases` rows. RM lookup stays per-block; the resolved RM is reused across phases via `rmOverride` so multi-phase blocks don't trigger redundant DB lookups.

## Changes

- `packages/parsers/src/workoutTextPreprocessor.ts` — `setSpecLine: string` → `setSpecLines: string[]`. Every spec line is captured; non-spec lines after the first spec collapse into block-level notes.
- `packages/parsers/src/index.ts` — `ParsedWorkoutBlock.parsed` → `phases`. `parseWorkoutText` parses each spec line; `missing` aggregates `'unparseable'` / `'rmSource'` across phases.
- `apps/mobile/PeakTrack/app/import-workout.tsx` — readiness checks, RM eager-resolution, save loop, and `BlockCard` rendering all iterate over `phases`. User-edited block notes attach to phase 0; per-phase RM source notes attach to each phase that needs them.
- `apps/web/peaktrack-app/app/routes/_app.workouts.import.tsx` — mirror of the mobile changes via `resolveWeights`.
- `packages/parsers/__tests__/{workoutTextPreprocessor,parseWorkoutText}.test.ts` — updated for the new shape and added cases for the user-reported Power Snatch input, between-spec notes, and multi-phase aggregation of `missing`.
- `docs/evil_empire/peakTrack/plans/fix-workout-import-multi-phase-plan.md` — the plan that drove the change.

## Test plan

- [x] `pnpm test --filter=@evil-empire/parsers` — 474 tests pass, including new multi-phase cases.
- [x] `pnpm typecheck` — all 13 packages pass.
- [ ] Mobile end-to-end: paste the Power Snatch sample on `pnpm dev:mobile`, confirm one card with three spec rows, resolve a Power Snatch 1RM, save, then re-open the workout and verify three phases with weights resolved per percentage.
- [x] Web end-to-end: same flow on `pnpm dev:web`.
- [x] Regression: re-import the existing 4-block reference paste from `parseWorkoutText.test.ts` to confirm single-spec blocks still produce one phase each with notes attached correctly.

https://claude.ai/code/session_01JgjzeBEELR1fqtLhckq9JP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgjzeBEELR1fqtLhckq9JP)_